### PR TITLE
builder: add Node type

### DIFF
--- a/src/types/builder.ts
+++ b/src/types/builder.ts
@@ -30,3 +30,11 @@ export interface NodeInfo {
   buildkitVersion?: string;
   platforms?: string;
 }
+
+export interface Node {
+  name?: string;
+  endpoint?: string;
+  'driver-opts'?: Array<string>;
+  'buildkitd-flags'?: string;
+  platforms?: string;
+}


### PR DESCRIPTION
For builder creation when appending additional nodes in `setup-buildx-action`.