### PR TITLE
buildx: split install from download and build methods

### DIFF
--- a/__tests__/buildx/install.test.ts
+++ b/__tests__/buildx/install.test.ts
@@ -43,7 +43,14 @@ describe('download', () => {
   ])(
   'acquires %p of buildx (standalone: %p)', async (version, standalone) => {
       const install = new Install({standalone: standalone});
-      const buildxBin = await install.download(version, tmpDir);
+      const toolPath = await install.download(version);
+      expect(fs.existsSync(toolPath)).toBe(true);
+      let buildxBin: string;
+      if (standalone) {
+        buildxBin = await install.installStandalone(toolPath, tmpDir);
+      } else {
+        buildxBin = await install.installPlugin(toolPath, tmpDir);
+      }
       expect(fs.existsSync(buildxBin)).toBe(true);
     },
     100000
@@ -65,7 +72,7 @@ describe('download', () => {
       jest.spyOn(osm, 'platform').mockImplementation(() => os);
       jest.spyOn(osm, 'arch').mockImplementation(() => arch);
       const install = new Install();
-      const buildxBin = await install.download('latest', tmpDir);
+      const buildxBin = await install.download('latest');
       expect(fs.existsSync(buildxBin)).toBe(true);
     },
     100000
@@ -82,14 +89,18 @@ describe('build', () => {
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip('builds refs/pull/648/head', async () => {
     const install = new Install();
-    const buildxBin = await install.build('https://github.com/docker/buildx.git#refs/pull/648/head', tmpDir);
+    const toolPath = await install.build('https://github.com/docker/buildx.git#refs/pull/648/head');
+    expect(fs.existsSync(toolPath)).toBe(true);
+    const buildxBin = await install.installStandalone(toolPath, tmpDir);
     expect(fs.existsSync(buildxBin)).toBe(true);
   }, 100000);
 
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip('builds 67bd6f4dc82a9cd96f34133dab3f6f7af803bb14', async () => {
     const install = new Install();
-    const buildxBin = await install.build('https://github.com/docker/buildx.git#67bd6f4dc82a9cd96f34133dab3f6f7af803bb14', tmpDir);
+    const toolPath = await install.build('https://github.com/docker/buildx.git#67bd6f4dc82a9cd96f34133dab3f6f7af803bb14');
+    expect(fs.existsSync(toolPath)).toBe(true);
+    const buildxBin = await install.installPlugin(toolPath, tmpDir);
     expect(fs.existsSync(buildxBin)).toBe(true);
   }, 100000);
 });

--- a/src/buildx/install.ts
+++ b/src/buildx/install.ts
@@ -102,6 +102,7 @@ export class Install {
   }
 
   public async installStandalone(toolPath: string, dest?: string): Promise<string> {
+    core.info('Standalone mode');
     dest = dest || this.context.tmpDir();
     const toolBinPath = path.join(toolPath, os.platform() == 'win32' ? 'docker-buildx.exe' : 'docker-buildx');
     const binDir = path.join(dest, 'bin');
@@ -111,13 +112,19 @@ export class Install {
     const filename: string = os.platform() == 'win32' ? 'buildx.exe' : 'buildx';
     const buildxPath: string = path.join(binDir, filename);
     fs.copyFileSync(toolBinPath, buildxPath);
+
+    core.info('Fixing perms');
     fs.chmodSync(buildxPath, '0755');
+
     core.addPath(binDir);
-    core.debug(`Install.installStandalone buildxPath: ${buildxPath}`);
+    core.info('Added Buildx to PATH');
+
+    core.info(`Binary path: ${buildxPath}`);
     return buildxPath;
   }
 
   public async installPlugin(toolPath: string, dest?: string): Promise<string> {
+    core.info('Docker plugin mode');
     dest = dest || Docker.configDir;
     const toolBinPath = path.join(toolPath, os.platform() == 'win32' ? 'docker-buildx.exe' : 'docker-buildx');
     const pluginsDir: string = path.join(dest, 'cli-plugins');
@@ -127,8 +134,11 @@ export class Install {
     const filename: string = os.platform() == 'win32' ? 'docker-buildx.exe' : 'docker-buildx';
     const pluginPath: string = path.join(pluginsDir, filename);
     fs.copyFileSync(toolBinPath, pluginPath);
+
+    core.info('Fixing perms');
     fs.chmodSync(pluginPath, '0755');
-    core.debug(`Install.installPlugin pluginPath: ${pluginPath}`);
+
+    core.info(`Plugin path: ${pluginPath}`);
     return pluginPath;
   }
 
@@ -172,9 +182,9 @@ export class Install {
   private async fetchBinary(version: string): Promise<string> {
     const targetFile: string = os.platform() == 'win32' ? 'docker-buildx.exe' : 'docker-buildx';
     const downloadURL = util.format('https://github.com/docker/buildx/releases/download/v%s/%s', version, this.filename(version));
+    core.info(`Downloading ${downloadURL}`);
     const downloadPath = await tc.downloadTool(downloadURL);
-    core.debug(`downloadURL: ${downloadURL}`);
-    core.debug(`downloadPath: ${downloadPath}`);
+    core.debug(`Install.fetchBinary downloadPath: ${downloadPath}`);
     return await tc.cacheFile(downloadPath, targetFile, 'buildx', version);
   }
 


### PR DESCRIPTION
Split install from download and build methods so we can have clear grouped output in `setup-buildx-action`.