### PR TITLE
git: alternative github context and additional methods

### DIFF
--- a/src/buildx/install.ts
+++ b/src/buildx/install.ts
@@ -73,7 +73,7 @@ export class Install {
     if (ref.match(/^[0-9a-fA-F]{40}$/)) {
       vspec = ref;
     } else {
-      vspec = await Git.getRemoteSha(repo, ref);
+      vspec = await Git.remoteSha(repo, ref);
     }
     core.debug(`Install.build: tool version spec ${vspec}`);
 

--- a/src/types/git.ts
+++ b/src/types/git.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2023 actions-toolkit authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Context as GitHubContext} from '@actions/github/lib/context';
+
+export type Context = GitHubContext;


### PR DESCRIPTION
follow-up https://github.com/docker/metadata-action/pull/248

Adds alternative context to the GitHub one for Git.

@neilime PTAL. I keep you posted when we cut a new release of the actions-toolkit so you can rebase your PR on the metadata-action repo. You could then have smth like:

```diff
---
 src/context.ts | 24 +++++++++++++++++++++++-
 1 file changed, 23 insertions(+), 1 deletion(-)

diff --git a/src/context.ts b/src/context.ts
index 3738b23..dd819c9 100644
--- a/src/context.ts
+++ b/src/context.ts
@@ -1,7 +1,11 @@
 import * as core from '@actions/core';
+import {Context} from '@actions/github/lib/context';
+import {Git} from '@docker/actions-toolkit/lib/git';
+import {GitHub} from '@docker/actions-toolkit/lib/github';
 import {Util} from '@docker/actions-toolkit/lib/util';
 
 export interface Inputs {
+  context: Context;
   images: string[];
   tags: string[];
   flavor: string[];
@@ -12,8 +16,9 @@ export interface Inputs {
   githubToken: string;
 }
 
-export function getInputs(): Inputs {
+export async function getInputs(): Promise<Inputs> {
   return {
+    context: await getContextInput('context'),
     images: Util.getInputList('images', {ignoreComma: true}),
     tags: Util.getInputList('tags', {ignoreComma: true}),
     flavor: Util.getInputList('flavor', {ignoreComma: true}),
@@ -24,3 +29,20 @@ export function getInputs(): Inputs {
     githubToken: core.getInput('github-token')
   };
 }
+
+export enum ContextSource {
+  workflow = 'workflow',
+  git = 'git'
+}
+
+async function getContextInput(name: string): Promise<Context> {
+  const input = core.getInput(name);
+  switch (input) {
+    case ContextSource.workflow:
+      return GitHub.context;
+    case ContextSource.git:
+      return await Git.context();
+    default:
+      throw new Error(`Invalid context: ${input}`);
+  }
+}
```