### PR TITLE
docker: fix context command

### DIFF
--- a/__tests__/docker.test.ts
+++ b/__tests__/docker.test.ts
@@ -63,7 +63,7 @@ describe('context', () => {
     await Docker.context().catch(() => {
       // noop
     });
-    expect(execSpy).toHaveBeenCalledWith(`docker`, ['context', 'show'], {
+    expect(execSpy).toHaveBeenCalledWith(`docker`, ['context', 'inspect', '--format', '{{.Name}}'], {
       ignoreReturnCode: true,
       silent: true
     });

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -38,8 +38,12 @@ export class Docker {
       });
   }
 
-  public static async context(): Promise<string> {
-    return await Exec.getExecOutput(`docker`, ['context', 'show'], {
+  public static async context(name?: string): Promise<string> {
+    const args = ['context', 'inspect', '--format', '{{.Name}}'];
+    if (name) {
+      args.push(name);
+    }
+    return await Exec.getExecOutput(`docker`, args, {
       ignoreReturnCode: true,
       silent: true
     }).then(res => {


### PR DESCRIPTION
Related to https://github.com/docker/setup-buildx-action/actions/runs/4270612172/jobs/7434517458#step:4:13

Looks like `docker context show` is only available since Docker 23: https://github.com/docker/cli/pull/3567.

What's odd is the command exists on Docker Desktop with Docker CLI 20.10.22 ??

```
$ docker --version
Docker version 20.10.22, build 3a2c30b
$ docker context --help
Manage contexts

Usage:
  docker context [command]

Available Commands:
  create      Create new context
  export      Export a context to a tar or kubeconfig file
  import      Import a context from a tar or zip file
  inspect     Display detailed information on one or more contexts
  list        List available contexts
  rm          Remove one or more contexts
  show        Print the current context
  update      Update a context
  use         Set the default context

Flags:
  -h, --help   Help for context

Use "docker context [command] --help" for more information about a command.
```

Do you have an idea why @thaJeztah? Maybe compose-cli handles it?