### PR TITLE
builder: fix regex to parse driver-opts

### DIFF
--- a/__tests__/buildx/builder.test.ts
+++ b/__tests__/buildx/builder.test.ts
@@ -38,7 +38,7 @@ jest.spyOn(Builder.prototype, 'inspect').mockImplementation(async (): Promise<Bu
       {
         buildkit: 'v0.11.0',
         'buildkitd-flags': '--debug --allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host',
-        'driver-opts': ['BUILDKIT_STEP_LOG_MAX_SIZE=10485760', 'BUILDKIT_STEP_LOG_MAX_SPEED=10485760', 'JAEGER_TRACE=localhost:6831', 'image=moby/buildkit:latest', 'network=host'],
+        'driver-opts': ['BUILDKIT_STEP_LOG_MAX_SIZE=10485760', 'BUILDKIT_STEP_LOG_MAX_SPEED=10485760', 'JAEGER_TRACE=localhost:6831', 'image=moby/buildkit:latest', 'network=host', 'qemu.install=true'],
         endpoint: 'unix:///var/run/docker.sock',
         name: 'builder20',
         platforms: 'linux/amd64,linux/amd64/v2,linux/amd64/v3,linux/arm64,linux/riscv64,linux/ppc64le,linux/s390x,linux/386,linux/mips64le,linux/mips64,linux/arm/v7,linux/arm/v6',
@@ -196,11 +196,12 @@ describe('parseInspect', () => {
            "buildkit": "v0.11.0",
            "buildkitd-flags": "--debug --allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host",
            "driver-opts": [
-             "BUILDKIT_STEP_LOG_MAX_SIZE=10485760",
-             "BUILDKIT_STEP_LOG_MAX_SPEED=10485760",
-             "JAEGER_TRACE=localhost:6831",
+             "env.BUILDKIT_STEP_LOG_MAX_SIZE=10485760",
+             "env.BUILDKIT_STEP_LOG_MAX_SPEED=10485760",
+             "env.JAEGER_TRACE=localhost:6831",
              "image=moby/buildkit:latest",
-             "network=host"
+             "network=host",
+             "qemu.install=true"
            ],
            "endpoint": "unix:///var/run/docker.sock",
            "name": "builder20",

--- a/__tests__/fixtures/inspect7.txt
+++ b/__tests__/fixtures/inspect7.txt
@@ -5,7 +5,7 @@ Last Activity: 2023-01-16 09:45:23 +0000 UTC
 Nodes:
 Name:           builder20
 Endpoint:       unix:///var/run/docker.sock
-Driver Options: env.BUILDKIT_STEP_LOG_MAX_SIZE="10485760" env.BUILDKIT_STEP_LOG_MAX_SPEED="10485760" env.JAEGER_TRACE="localhost:6831" image="moby/buildkit:latest" network="host"
+Driver Options: env.BUILDKIT_STEP_LOG_MAX_SIZE="10485760" env.BUILDKIT_STEP_LOG_MAX_SPEED="10485760" env.JAEGER_TRACE="localhost:6831" image="moby/buildkit:latest" network="host" qemu.install="true"
 Status:         running
 Flags:          --debug --allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host
 Buildkit:       v0.11.0

--- a/src/buildx/builder.ts
+++ b/src/buildx/builder.ts
@@ -105,7 +105,7 @@ export class Builder {
           break;
         }
         case 'driver options': {
-          node['driver-opts'] = (value.match(/(\w+)="([^"]*)"/g) || []).map(v => v.replace(/^(.*)="(.*)"$/g, '$1=$2'));
+          node['driver-opts'] = (value.match(/([a-zA-Z0-9_.]+)="([^"]*)"/g) || []).map(v => v.replace(/^(.*)="(.*)"$/g, '$1=$2'));
           break;
         }
         case 'status': {


### PR DESCRIPTION
Encounter this issue while working on https://github.com/docker/setup-buildx-action/pull/219

See https://github.com/docker/setup-buildx-action/actions/runs/4392990659/jobs/7693097407#step:4:179