### PR TITLE
build(deps): bump csv-parse from 5.3.5 to 5.3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@actions/io": "^1.1.2",
     "@actions/tool-cache": "^2.0.1",
     "async-retry": "^1.3.3",
-    "csv-parse": "^5.3.5",
+    "csv-parse": "^5.3.6",
     "handlebars": "^4.7.7",
     "jwt-decode": "^3.1.2",
     "semver": "^7.3.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -776,7 +776,7 @@ __metadata:
     "@typescript-eslint/parser": ^5.49.0
     async-retry: ^1.3.3
     cpy-cli: ^4.2.0
-    csv-parse: ^5.3.5
+    csv-parse: ^5.3.6
     dotenv: ^16.0.3
     eslint: ^8.33.0
     eslint-config-prettier: ^8.6.0
@@ -2573,7 +2573,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"csv-parse@npm:*, csv-parse@npm:^5.3.5":
+"csv-parse@npm:*, csv-parse@npm:^5.3.6":
   version: 5.3.6
   resolution: "csv-parse@npm:5.3.6"
   checksum: a6dcb61a0676121e84a29cdee4978a0516d1412fbe8895057d17e1a95a2013e6283b253135465ad562222d095988a74587d92b2fa04192bef15090acce2a0433


### PR DESCRIPTION
Looks like dependabot didn't update the `package.json` in https://github.com/docker/actions-toolkit/pull/65/files