### PR TITLE
✨ Add support to secret env

### DIFF
--- a/__tests__/buildx/inputs.test.ts
+++ b/__tests__/buildx/inputs.test.ts
@@ -177,6 +177,21 @@ describe('resolveBuildSecret', () => {
       expect(e.message).toEqual(error?.message);
     }
   });
+
+  test.each([
+    ['FOO=bar', 'FOO', 'bar', null],
+    ['FOO=', 'FOO', '', new Error('FOO= is not a valid secret')],
+    ['=bar', '', '', new Error('=bar is not a valid secret')],
+    ['FOO=bar=baz', 'FOO', 'bar=baz', null]
+  ])('given %p key and %p env', async (kvp: string, exKey: string, exValue: string, error: Error | null) => {
+    try {
+      const secret = Inputs.resolveBuildSecretEnv(kvp);
+      expect(secret).toEqual(`id=${exKey},env="${exValue}"`);
+    } catch (e) {
+      // eslint-disable-next-line jest/no-conditional-expect
+      expect(e.message).toEqual(error?.message);
+    }
+  });
 });
 
 describe('hasLocalExporter', () => {


### PR DESCRIPTION
Allow to use environment variables as secret during docker build.

---

Eventually we need pass some environment variables to docker build to allow interactions with dynamic sources like AWS.

Those environment variables are avaible after some previous github actions steps, like [`configure-aws-credentials`](https://github.com/aws-actions/configure-aws-credentials)

I use the [docker/build-push-action](https://github.com/docker/build-push-action) action in a very strict environment, is encapsulated by other actions who I don't have access directly.

This change (and another change in build-push-action) will unlock this limitation and solve the problem.

```
docker build --progress plain \
    --secret id=AWS_ACCESS_KEY_ID,env="AWS_ACCESS_KEY_ID" \
    --secret id=AWS_SECRET_ACCESS_KEY,env="AWS_SECRET_ACCESS_KEY" \
    --secret id=AWS_SESSION_TOKEN,env="AWS_SESSION_TOKEN" \
    -t image:tag
```