### PR TITLE
docker: configFile method

### DIFF
--- a/__tests__/fixtures/docker-config-auths.json
+++ b/__tests__/fixtures/docker-config-auths.json
@@ -1,0 +1,8 @@
+{
+	"auths": {
+		"https://index.docker.io/v1/": {
+			"auth": "am9lam9lOmhlbGxv",
+			"email": "user@example.com"
+		}
+	}
+}

--- a/__tests__/fixtures/docker-config-proxies.json
+++ b/__tests__/fixtures/docker-config-proxies.json
@@ -1,0 +1,8 @@
+{
+  "proxies": {
+    "default": {
+      "httpProxy": "http://127.0.0.1:3128",
+      "httpsProxy": "http://127.0.0.1:3128"
+    }
+  }
+}

--- a/src/docker/docker.ts
+++ b/src/docker/docker.ts
@@ -14,15 +14,27 @@
  * limitations under the License.
  */
 
+import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import * as core from '@actions/core';
 import * as io from '@actions/io';
+
 import {Exec} from '../exec';
+
+import {ConfigFile} from '../types/docker';
 
 export class Docker {
   static get configDir(): string {
     return process.env.DOCKER_CONFIG || path.join(os.homedir(), '.docker');
+  }
+
+  public static configFile(): ConfigFile | undefined {
+    const f = path.join(Docker.configDir, 'config.json');
+    if (!fs.existsSync(f)) {
+      return undefined;
+    }
+    return <ConfigFile>JSON.parse(fs.readFileSync(f, {encoding: 'utf-8'}));
   }
 
   public static async isAvailable(): Promise<boolean> {

--- a/src/types/docker.ts
+++ b/src/types/docker.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2023 actions-toolkit authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// https://github.com/docker/cli/blob/master/cli/config/configfile/file.go
+export interface ConfigFile {
+  auths: Record<string, AuthConfig>;
+  HttpHeaders?: Record<string, string>;
+  psFormat?: string;
+  imagesFormat?: string;
+  networksFormat?: string;
+  pluginsFormat?: string;
+  volumesFormat?: string;
+  statsFormat?: string;
+  detachKeys?: string;
+  credsStore?: string;
+  credHelpers?: Record<string, string>;
+  serviceInspectFormat?: string;
+  servicesFormat?: string;
+  tasksFormat?: string;
+  secretFormat?: string;
+  configFormat?: string;
+  nodesFormat?: string;
+  pruneFilters?: string[];
+  proxies?: Record<string, ProxyConfig>;
+  experimental?: string;
+  stackOrchestrator?: string;
+  kubernetes?: KubernetesConfig;
+  currentContext?: string;
+  cliPluginsExtraDirs?: string[];
+  plugins?: Record<string, Record<string, string>>;
+  aliases?: Record<string, string>;
+}
+
+export interface ProxyConfig {
+  httpProxy?: string;
+  httpsProxy?: string;
+  noProxy?: string;
+  ftpProxy?: string;
+}
+
+export interface KubernetesConfig {
+  allNamespaces?: string;
+}
+
+export interface AuthConfig {
+  username?: string;
+  password?: string;
+  auth?: string;
+  email?: string;
+  serveraddress?: string;
+  identitytoken?: string;
+  registrytoken?: string;
+}


### PR DESCRIPTION
related to https://github.com/docker/build-push-action/pull/872

We need a way to inform users that proxy configuration from docker config might be used and could potentially affect their builds in workflows. Could have been done using the buildx inspect command in https://github.com/docker/buildx/pull/1864 but this is not really suitable.