### PR TITLE
buildx: build for local platform

### DIFF
--- a/src/buildx/install.ts
+++ b/src/buildx/install.ts
@@ -177,7 +177,7 @@ export class Install {
       throw new Error(`Neither buildx standalone or plugin have been found to build from ref ${gitContext}`);
     }
 
-    const args = ['build', '--target', 'binaries', '--build-arg', 'BUILDKIT_CONTEXT_KEEP_GIT_DIR=1', '--output', `type=local,dest=${outputDir}`];
+    const args = ['build', '--target', 'binaries', '--platform', 'local', '--build-arg', 'BUILDKIT_CONTEXT_KEEP_GIT_DIR=1', '--output', `type=local,dest=${outputDir}`];
     if (process.env.GIT_AUTH_TOKEN) {
       args.push('--secret', 'id=GIT_AUTH_TOKEN');
     }


### PR DESCRIPTION
When building buildx on macOS runner when Docker engine is installed it will build against `linux/amd64` instead of `darwin/amd64`. We should always match the local platform.

cc @maxcleme