### PR TITLE
chore: set increase as versioning strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    versioning-strategy: "increase"
     allow:
       - dependency-type: "production"
     labels:


### PR DESCRIPTION
Looking at https://github.com/docker/actions-toolkit/pull/143/files it doesn't seem to update the `package.json` anymore. Was pretty sure it was doing that before. But anyway we can fix that by setting the versioning-strategy to `increase`: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy