### PR TITLE
docker(install): SIGN_QEMU_BINARY env as workaround to replace existing signature

### DIFF
--- a/__tests__/docker/install.test.itg.ts
+++ b/__tests__/docker/install.test.itg.ts
@@ -15,7 +15,7 @@
  */
 
 import path from 'path';
-import {jest, describe, expect, test} from '@jest/globals';
+import {jest, describe, expect, test, beforeEach, afterEach} from '@jest/globals';
 
 import {Install} from '../../src/docker/install';
 import {Docker} from '../../src/docker/docker';
@@ -24,7 +24,17 @@ import {Docker} from '../../src/docker/docker';
 const tmpDir = path.join(process.env.TEMP || '/tmp', 'docker-install-jest');
 
 describe('install', () => {
-  jest.retryTimes(2, {logErrorsBeforeRetry: true});
+  const originalEnv = process.env;
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = {
+      ...originalEnv,
+      SIGN_QEMU_BINARY: '1'
+    };
+  });
+  afterEach(() => {
+    process.env = originalEnv;
+  });
   // prettier-ignore
   test.each(['v24.0.5'])(
     'install docker %s', async (version) => {
@@ -40,5 +50,5 @@ describe('install', () => {
         await Docker.printInfo();
         await install.tearDown();
       })()).resolves.not.toThrow();
-    }, 100000);
+    }, 600000);
 });

--- a/src/docker/assets.ts
+++ b/src/docker/assets.ts
@@ -336,3 +336,14 @@ mounts: []
 # Default: {}
 env: {}
 `;
+
+export const qemuEntitlements = `
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.hypervisor</key>
+    <true/>
+</dict>
+</plist>
+`;

--- a/src/docker/install.ts
+++ b/src/docker/install.ts
@@ -155,7 +155,15 @@ export class Install {
       [key: string]: string;
     };
     await core.group('Starting colima', async () => {
-      await Exec.exec('colima', ['start', '--very-verbose'], {env: envs});
+      try {
+        await Exec.exec('colima', ['start', '--very-verbose'], {env: envs});
+      } catch (e) {
+        const haStderrLog = path.join(os.homedir(), '.lima', 'colima', 'ha.stderr.log');
+        if (fs.existsSync(haStderrLog)) {
+          core.info(`Printing debug logs (${haStderrLog}):\n${fs.readFileSync(haStderrLog, {encoding: 'utf8'})}`);
+        }
+        throw e;
+      }
     });
 
     await core.group('Create Docker context', async () => {


### PR DESCRIPTION
follow-up https://github.com/docker/actions-toolkit/pull/150#issuecomment-1694196417

Adds `SIGN_QEMU_BINARY` env as workaround to replace existing signature with required entitlements per https://github.com/abiosoft/colima/issues/786#issuecomment-1693629650. Also adds extra commit to display debug logs on failure.