### PR TITLE
docker(install): stop docker daemon gracefully on linux

### DIFF
--- a/src/docker/assets.ts
+++ b/src/docker/assets.ts
@@ -72,6 +72,7 @@ mkdir -p "$RUNDIR"
   echo "Starting dockerd"
   set -x
   exec dockerd \\
+    --debug \\
     --host="$DOCKER_HOST" \\
     --exec-root="$RUNDIR/execroot" \\
     --data-root="$RUNDIR/data" \\

--- a/src/docker/install.ts
+++ b/src/docker/install.ts
@@ -311,13 +311,17 @@ export class Install {
       core.info(fs.readFileSync(path.join(this.runDir, 'dockerd.log'), {encoding: 'utf8'}));
     });
     await core.group('Stopping Docker daemon', async () => {
-      await Exec.exec('sudo', ['kill', fs.readFileSync(path.join(this.runDir, 'docker.pid')).toString().trim()]);
+      await Exec.exec('sudo', ['kill', '-s', 'SIGTERM', fs.readFileSync(path.join(this.runDir, 'docker.pid')).toString().trim()]);
+      await Util.sleep(5);
     });
     await core.group('Removing Docker context', async () => {
       await Exec.exec('docker', ['context', 'rm', '-f', this.contextName]);
     });
     await core.group(`Cleaning up runDir`, async () => {
-      await Exec.exec('sudo', ['rm', '-rf', this.runDir]);
+      await Exec.exec('sudo', ['rm', '-rf', this.runDir], {
+        ignoreReturnCode: true,
+        failOnStdErr: false
+      });
     });
   }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -133,4 +133,8 @@ export class Util {
     }
     return str.substring(0, index);
   }
+
+  public static sleep(seconds: number) {
+    return new Promise(resolve => setTimeout(resolve, seconds * 1000));
+  }
 }


### PR DESCRIPTION
related to: https://github.com/crazy-max/ghaction-setup-docker/actions/runs/5984159898/job/16235064091#step:13:27

```
Cleaning up runDir
  /usr/bin/sudo rm -rf /home/runner/setup-docker-action-b2d1aae1-6bc5-48e6-b3d2-3f6b0ff55a03
  rm: cannot remove '/home/runner/setup-docker-action-b2d1aae1-6bc5-48e6-b3d2-3f6b0ff55a03/execroot/netns/73797e176e19': Device or resource busy
  rm: cannot remove '/home/runner/setup-docker-action-b2d1aae1-6bc5-48e6-b3d2-3f6b0ff55a03/data/overlay2/dd999632be8bbc1d1b90e1c22d3ad56c9ede1ff04b50b54af1877f0617de17d7/merged': Device or resource busy
```