### PR TITLE
Remove quotes around env variable name in resolveBuildSecretEnv

### DIFF
--- a/__tests__/buildx/inputs.test.ts
+++ b/__tests__/buildx/inputs.test.ts
@@ -186,7 +186,7 @@ describe('resolveBuildSecret', () => {
   ])('given %p key and %p env', async (kvp: string, exKey: string, exValue: string, error: Error | null) => {
     try {
       const secret = Inputs.resolveBuildSecretEnv(kvp);
-      expect(secret).toEqual(`id=${exKey},env="${exValue}"`);
+      expect(secret).toEqual(`id=${exKey},env=${exValue}`);
     } catch (e) {
       // eslint-disable-next-line jest/no-conditional-expect
       expect(e.message).toEqual(error?.message);

--- a/src/buildx/inputs.ts
+++ b/src/buildx/inputs.ts
@@ -85,7 +85,7 @@ export class Inputs {
   public static resolveBuildSecretEnv(kvp: string): string {
     const [key, value] = parseKvp(kvp);
 
-    return `id=${key},env="${value}"`;
+    return `id=${key},env=${value}`;
   }
 
   public static resolveBuildSecret(kvp: string, file: boolean): string {


### PR DESCRIPTION
When trying to implement an input for secrets defined by environment variables to the [build-push-action](https://github.com/elias-lundgren/docker-build-push-action) I made use of the new `resolveBuildSecretEnv` implemented in: https://github.com/docker/actions-toolkit/commit/a1ffbe96065f5934066c01459a17967107273cc6.

I implemented [a test](https://github.com/elias-lundgren/docker-build-push-action/blob/70138029d25c33c53e7050d2f0fc8279ea5574d9/.github/workflows/ci.yml#L396-L419) for the new input and it didn't work due to csv parsing breaking because of the quotes around the env variable name as can be seen [here](https://github.com/elias-lundgren/docker-build-push-action/actions/runs/6314626381). After monkeypatching this function (removing the `"` around the env variable name) and building again it works correctly as can be seen [here](https://github.com/elias-lundgren/docker-build-push-action/actions/runs/6314903468).

Pasting images since action runs disappear after a while:
<img width="1258" alt="image" src="https://github.com/docker/actions-toolkit/assets/145569914/4a74a306-db93-4664-bc94-266c98c08d77">
<img width="1270" alt="image" src="https://github.com/docker/actions-toolkit/assets/145569914/b4f62946-62ce-41e7-bd65-c8fc89388d1d">

