### PR TITLE
Respect RUNNER_TEMP environment variable

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -23,7 +23,17 @@ import * as github from '@actions/github';
 import {GitHub} from './github';
 
 export class Context {
-  private static readonly _tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'docker-actions-toolkit-'));
+  private static readonly _tmpDir = fs.mkdtempSync(path.join(Context._tryCreateDirctory(process.env.RUNNER_TEMP) || os.tmpdir(), 'docker-actions-toolkit-'));
+
+  private static _tryCreateDirctory(directoryPath: string | undefined): string | undefined {
+    if (directoryPath !== undefined) {
+      const createdPath = fs.mkdirSync(directoryPath, {recursive: true});
+      if (createdPath !== directoryPath) {
+        return undefined;
+      }
+    }
+    return directoryPath;
+  }
 
   public static tmpDir(): string {
     return Context._tmpDir;


### PR DESCRIPTION
On some (self hosted) runners `os.tmpdir()` cannot be used to communicate between applications. For example when using snap, every snap will get it's own, isolated, `os.tmpdir()`.

Github already provides us with an environment variable, `RUNNER_TEMP`, that should point to a directory that we can use as a temporary storage location that should be accessible by different applications on the same host. This change will use the directory pointed to by `RUNNER_TEMP` as base for tmpDir when the variable is defined and the directory can be created or already existed