### PR TITLE
docker: parseRepoTag and pull methods

### DIFF
--- a/__tests__/docker/docker.test.itg.ts
+++ b/__tests__/docker/docker.test.itg.ts
@@ -23,13 +23,34 @@ const maybe = !process.env.GITHUB_ACTIONS || (process.env.GITHUB_ACTIONS === 'tr
 maybe('pull', () => {
   // prettier-ignore
   test.each([
-    'busybox',
-    'busybox:1.36',
-    'busybox@sha256:7ae8447f3a7f5bccaa765926f25fc038e425cf1b2be6748727bbea9a13102094'
-  ])(
-    'pulling %s', async (image) => {
-      await expect((async () => {
+    [
+      'busybox',
+      undefined,
+    ],
+    [
+      'busybox:1.36',
+      undefined,
+    ],
+    [
+      'busybox@sha256:7ae8447f3a7f5bccaa765926f25fc038e425cf1b2be6748727bbea9a13102094',
+      undefined,
+    ],
+    [
+      'doesnotexist:foo',
+      `pull access denied for doesnotexist`,
+    ],
+  ])('pulling %p', async (image: string, err: string | undefined) => {
+      try {
         await Docker.pull(image, true);
-      })()).resolves.not.toThrow();
+        if (err !== undefined) {
+          throw new Error('Expected an error to be thrown');
+        }
+      } catch (e) {
+        if (err === undefined) {
+          throw new Error(`Expected no error, but got: ${e.message}`);
+        }
+        // eslint-disable-next-line jest/no-conditional-expect
+        expect(e.message).toContain(err);
+      }
     }, 600000);
 });

--- a/__tests__/docker/docker.test.itg.ts
+++ b/__tests__/docker/docker.test.itg.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2024 actions-toolkit authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {describe, expect, test} from '@jest/globals';
+
+import {Docker} from '../../src/docker/docker';
+
+const maybe = !process.env.GITHUB_ACTIONS || (process.env.GITHUB_ACTIONS === 'true' && process.env.ImageOS && process.env.ImageOS.startsWith('ubuntu')) ? describe : describe.skip;
+
+maybe('pull', () => {
+  // prettier-ignore
+  test.each([
+    'busybox',
+    'busybox:1.36',
+    'busybox@sha256:7ae8447f3a7f5bccaa765926f25fc038e425cf1b2be6748727bbea9a13102094'
+  ])(
+    'pulling %s', async (image) => {
+      await expect((async () => {
+        await Docker.pull(image, true);
+      })()).resolves.not.toThrow();
+    }, 600000);
+});

--- a/src/docker/docker.ts
+++ b/src/docker/docker.ts
@@ -20,7 +20,10 @@ import path from 'path';
 import * as core from '@actions/core';
 import * as io from '@actions/io';
 
+import {Context} from '../context';
+import {Cache} from '../cache';
 import {Exec} from '../exec';
+import {Util} from '../util';
 
 import {ConfigFile} from '../types/docker';
 
@@ -72,5 +75,79 @@ export class Docker {
 
   public static async printInfo(): Promise<void> {
     await Exec.exec('docker', ['info']);
+  }
+
+  public static parseRepoTag(image: string): {repository: string; tag: string} {
+    let sepPos: number;
+    const digestPos = image.indexOf('@');
+    const colonPos = image.lastIndexOf(':');
+    if (digestPos >= 0) {
+      // priority on digest
+      sepPos = digestPos;
+    } else if (colonPos >= 0) {
+      sepPos = colonPos;
+    } else {
+      return {
+        repository: image,
+        tag: 'latest'
+      };
+    }
+    const tag = image.slice(sepPos + 1);
+    if (tag.indexOf('/') === -1) {
+      return {
+        repository: image.slice(0, sepPos),
+        tag: tag
+      };
+    }
+    return {
+      repository: image,
+      tag: 'latest'
+    };
+  }
+
+  public static async pull(image: string, cache?: boolean): Promise<void> {
+    const parsedImage = Docker.parseRepoTag(image);
+    const repoSanitized = parsedImage.repository.replace(/[^a-zA-Z0-9.]+/g, '--');
+    const tagSanitized = parsedImage.tag.replace(/[^a-zA-Z0-9.]+/g, '--');
+
+    const imageCache = new Cache({
+      htcName: repoSanitized,
+      htcVersion: tagSanitized,
+      baseCacheDir: path.join(Docker.configDir, '.cache', 'images', repoSanitized),
+      cacheFile: 'image.tar'
+    });
+
+    let cacheFoundPath: string | undefined;
+    if (cache) {
+      cacheFoundPath = await imageCache.find();
+      if (cacheFoundPath) {
+        core.info(`Image found from cache in ${cacheFoundPath}`);
+        await Exec.getExecOutput(`docker`, ['load', '-i', cacheFoundPath]).catch(e => {
+          core.warning(`Failed to load image from cache: ${e}`);
+        });
+      }
+    }
+
+    let pulled = true;
+    await Exec.getExecOutput(`docker`, ['pull', image]).catch(e => {
+      pulled = false;
+      if (cacheFoundPath) {
+        core.warning(`Failed to pull image, using one from cache: ${e}`);
+      } else {
+        throw new Error(e);
+      }
+    });
+
+    if (cache && pulled) {
+      const imageTarPath = path.join(Context.tmpDir(), `${Util.hash(image)}.tar`);
+      await Exec.getExecOutput(`docker`, ['save', '-o', imageTarPath, image])
+        .then(async () => {
+          const cachePath = await imageCache.save(imageTarPath);
+          core.info(`Image cached to ${cachePath}`);
+        })
+        .catch(e => {
+          core.warning(`Failed to save image: ${e}`);
+        });
+    }
   }
 }


### PR DESCRIPTION
fixes https://github.com/docker/setup-qemu-action/issues/122
closes https://github.com/docker/setup-qemu-action/pull/125

Adds `parseRepoTag` and `pull` to docker module. `pull` has been added to add cache support related to https://github.com/docker/setup-qemu-action/issues/110 and https://github.com/crazy-max/ghaction-xgo/issues/224