### PR TITLE
docker(install): fallback to journalctl to print docker daemon logs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,9 +78,12 @@ jobs:
         test: ${{ fromJson(needs.prepare-itg.outputs.matrix) }}
         os:
           - ubuntu-latest
+          - macos-13
           - macos-latest
           - windows-latest
         exclude:
+          - os: macos-13
+            test: buildx/bake.test.itg.ts
           - os: macos-latest
             test: buildx/bake.test.itg.ts
           - os: windows-latest

--- a/__tests__/docker/install.test.itg.ts
+++ b/__tests__/docker/install.test.itg.ts
@@ -30,7 +30,7 @@ describe('install', () => {
     process.env = {
       ...originalEnv,
       SIGN_QEMU_BINARY: '1',
-      COLIMA_START_ARGS: '--cpu 4 --memory 8 --disk 32 --dns 1.1.1.1 --dns 8.8.8.8 --dns-host example.com=1.2.3.4'
+      COLIMA_START_ARGS: '--cpu 4 --memory 8 --disk 32'
     };
   });
   afterEach(() => {
@@ -52,5 +52,5 @@ describe('install', () => {
         await Docker.printInfo();
         await install.tearDown();
       })()).resolves.not.toThrow();
-    }, 600000);
+    }, 1200000);
 });

--- a/src/docker/assets.ts
+++ b/src/docker/assets.ts
@@ -256,10 +256,7 @@ cpuType: host
 provision:
   - mode: system
     script: |
-      mkdir -p /tmp/docker-bins
-      cd /tmp/docker-bins
-      wget -qO- "https://download.docker.com/linux/static/{{dockerBinChannel}}/{{dockerBinArch}}/docker-{{dockerBinVersion}}.tgz" | tar xvz --strip 1
-      mv -f /tmp/docker-bins/* /usr/bin/
+      wget -qO- "https://download.docker.com/linux/static/{{dockerBinChannel}}/{{dockerBinArch}}/docker-{{dockerBinVersion}}.tgz" | tar xvz --strip 1 -C /usr/bin/
 
 # Modify ~/.ssh/config automatically to include a SSH config for the virtual machine.
 # SSH config will still be generated in ~/.colima/ssh_config regardless.

--- a/src/docker/assets.ts
+++ b/src/docker/assets.ts
@@ -187,12 +187,6 @@ network:
   dnsHosts:
     host.docker.internal: host.lima.internal
 
-  # Network driver to use (slirp, gvproxy), (requires vmType \`qemu\`)
-  #   - slirp is the default user mode networking provided by Qemu
-  #   - gvproxy is an alternative to VPNKit based on gVisor https://github.com/containers/gvisor-tap-vsock
-  # Default: gvproxy
-  driver: gvproxy
-
 # Forward the host's SSH agent to the virtual machine.
 # Default: false
 forwardAgent: false
@@ -241,14 +235,6 @@ mountType: 9p
 # Instructions are also supported by appending to the cpu type e.g. "qemu64,+ssse3".
 # Default: host
 cpuType: host
-
-# For a more general purpose virtual machine, Ubuntu container is optionally provided
-# as a layer on the virtual machine.
-# The underlying virtual machine is still accessible via \`colima ssh --layer=false\` or running \`colima\` in
-# the Ubuntu session.
-#
-# Default: false
-layer: false
 
 # Custom provision scripts for the virtual machine.
 # Provisioning scripts are executed on startup and therefore needs to be idempotent.

--- a/src/docker/install.ts
+++ b/src/docker/install.ts
@@ -362,7 +362,11 @@ EOF`,
 
   private async tearDownDarwin(): Promise<void> {
     await core.group('Docker daemon logs', async () => {
-      await Exec.exec('colima', ['exec', '--', 'cat', '/var/log/docker.log']);
+      await Exec.exec('colima', ['exec', '--', 'cat', '/var/log/docker.log']).catch(async () => {
+        await Exec.exec('colima', ['exec', '--', 'sudo', 'journalctl', '-u', 'docker.service', '-l', '--no-pager']).catch(() => {
+          core.warning(`Failed to get Docker daemon logs`);
+        });
+      });
     });
     await core.group('Stopping colima', async () => {
       await Exec.exec('colima', ['stop', '--very-verbose']);


### PR DESCRIPTION
related to https://github.com/crazy-max/ghaction-setup-docker/issues/45

colima only supports Ubuntu image since 0.6.0 which runs docker as systemd unit: https://github.com/abiosoft/colima/blob/main/docs/FAQ.md#version-v060-and-newer

> ### Version v0.6.0 and newer
> 
> Colima uses Ubuntu as the underlying image. Other distros are not supported.