### PR TITLE
docker(install): allow specifying custom lima images

### DIFF
--- a/__tests__/docker/install.test.itg.ts
+++ b/__tests__/docker/install.test.itg.ts
@@ -29,7 +29,9 @@ describe('install', () => {
     jest.resetModules();
     process.env = {
       ...originalEnv,
-      LIMA_START_ARGS: '--cpus 4 --memory 8'
+      LIMA_START_ARGS: '--cpus 4 --memory 8',
+      LIMA_IMAGES: `x86_64:https://cloud.debian.org/images/cloud/bookworm/20231013-1532/debian-12-genericcloud-amd64-20231013-1532.qcow2@sha512:6b55e88b027c14da1b55c85a25a9f7069d4560a8fdb2d948c986a585db469728a06d2c528303e34bb62d8b2984def38fd9ddfc00965846ff6e05b01d6e883bfe
+aarch64:https://cloud.debian.org/images/cloud/bookworm/20231013-1532/debian-12-genericcloud-arm64-20231013-1532.qcow2`
     };
   });
   afterEach(() => {

--- a/__tests__/docker/install.test.ts
+++ b/__tests__/docker/install.test.ts
@@ -71,3 +71,32 @@ describe('getRelease', () => {
     await expect(Install.getRelease('foo')).rejects.toThrow(new Error('Cannot find Docker release foo in https://raw.githubusercontent.com/docker/actions-toolkit/main/.github/docker-releases.json'));
   });
 });
+
+describe('limaImage', () => {
+  const originalEnv = process.env;
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = {
+      ...originalEnv,
+      LIMA_IMAGES: `x86_64:https://cloud-images.ubuntu.com/releases/23.10/release-20231011/ubuntu-23.10-server-cloudimg-amd64.img@sha256:f6529be56da3429a56e4f5ef202bf4958201bc63f8541e478caa6e8eb712e635
+aarch64:https://cloud-images.ubuntu.com/releases/23.10/release-20231011/ubuntu-23.10-server-cloudimg-arm64.img`
+    };
+  });
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+  it('returns custom images', async () => {
+    expect(Install.limaCustomImages()).toEqual([
+      {
+        location: 'https://cloud-images.ubuntu.com/releases/23.10/release-20231011/ubuntu-23.10-server-cloudimg-amd64.img',
+        arch: 'x86_64',
+        digest: 'sha256:f6529be56da3429a56e4f5ef202bf4958201bc63f8541e478caa6e8eb712e635'
+      },
+      {
+        location: 'https://cloud-images.ubuntu.com/releases/23.10/release-20231011/ubuntu-23.10-server-cloudimg-arm64.img',
+        arch: 'aarch64',
+        digest: ''
+      }
+    ]);
+  });
+});

--- a/src/docker/assets.ts
+++ b/src/docker/assets.ts
@@ -144,6 +144,11 @@ os: null
 arch: null
 
 images:
+{{#each customImages}}
+- location: "{{location}}"
+  arch: "{{arch}}"
+  digest: "{{digest}}"
+{{/each}}
 - location: "https://cloud-images.ubuntu.com/releases/22.04/release-20231026/ubuntu-22.04-server-cloudimg-amd64.img"
   arch: "x86_64"
   digest: "sha256:054db2d88c454bb0ad8dfd8883955e3946b57d2b0bf0d023f3ade3c93cdd14e5"

--- a/src/docker/install.ts
+++ b/src/docker/install.ts
@@ -136,8 +136,9 @@ export class Install {
     await io.mkdirP(limaDir);
     const dockerHost = `unix://${limaDir}/docker.sock`;
 
-    // avoid brew to upgrade unrelated packages.
+    // avoid brew to auto update and upgrade unrelated packages.
     let envs = Object.assign({}, process.env, {
+      HOMEBREW_NO_AUTO_UPDATE: '1',
       HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: '1'
     }) as {
       [key: string]: string;

--- a/src/docker/install.ts
+++ b/src/docker/install.ts
@@ -150,6 +150,10 @@ export class Install {
       });
     }
 
+    await core.group('Lima version', async () => {
+      await Exec.exec('lima', ['--version'], {env: envs});
+    });
+
     await core.group('Creating lima config', async () => {
       let limaDaemonConfig = {};
       if (this.daemonConfig) {
@@ -183,7 +187,7 @@ export class Install {
     };
 
     await core.group('Starting lima instance', async () => {
-      const limaStartArgs = ['start', `--name=${this.limaInstanceName}`, '--tty=false'];
+      const limaStartArgs = ['start', `--name=${this.limaInstanceName}`];
       if (process.env.LIMA_START_ARGS) {
         limaStartArgs.push(process.env.LIMA_START_ARGS);
       }

--- a/src/util.ts
+++ b/src/util.ts
@@ -19,22 +19,24 @@ import * as core from '@actions/core';
 import * as io from '@actions/io';
 import {parse} from 'csv-parse/sync';
 
-export interface InputListOpts {
+export interface ListOpts {
   ignoreComma?: boolean;
   comment?: string;
   quote?: string | boolean | Buffer | null;
 }
 
 export class Util {
-  public static getInputList(name: string, opts?: InputListOpts): string[] {
-    const res: Array<string> = [];
+  public static getInputList(name: string, opts?: ListOpts): string[] {
+    return this.getList(core.getInput(name), opts);
+  }
 
-    const items = core.getInput(name);
-    if (items == '') {
+  public static getList(input: string, opts?: ListOpts): string[] {
+    const res: Array<string> = [];
+    if (input == '') {
       return res;
     }
 
-    const records = parse(items, {
+    const records = parse(input, {
       columns: false,
       relaxQuotes: true,
       comment: opts?.comment,


### PR DESCRIPTION
related to https://github.com/crazy-max/ghaction-setup-docker/actions/runs/7158220214/job/19490045126?pr=48#step:3:146

```
/usr/local/bin/limactl start --name=docker-actions-toolkit --tty=false
  time="2023-12-10T13:49:57Z" level=info msg="Using the existing instance \"docker-actions-toolkit\""
  time="2023-12-10T13:49:57Z" level=info msg="QEMU binary \"/usr/local/bin/qemu-system-x86_64\" seems properly signed with the \"com.apple.security.hypervisor\" entitlement"
  time="2023-12-10T13:49:57Z" level=info msg="Attempting to download the image" arch=x86_64 digest="sha256:054db2d88c454bb0ad8dfd8883955e3946b57d2b0bf0d023f3ade3c93cdd14e5" location="https://cloud-images.ubuntu.com/releases/22.04/release-20231026/ubuntu-22.04-server-cloudimg-amd64.img"
  Downloading the image (ubuntu-22.04-server-cloudimg-amd64.img)
  time="2023-12-10T13:50:02Z" level=fatal msg="failed to download \"[https://cloud-images.ubuntu.com/releases/22.04/release-20231026/ubuntu-22.04-server-cloudimg-amd64.img\](https://cloud-images.ubuntu.com/releases/22.04/release-20231026/ubuntu-22.04-server-cloudimg-amd64.img/)": read tcp 192.168.64.23:49180->185.125.190.37:443: read: connection reset by peer"
Error: The process '/usr/local/bin/limactl' failed with exit code 1
```

Ubuntu or debian mirrors to download cloud images can be flaky on macOS runners so to avoid blocking users, they can provide their own image if they want to.