### PR TITLE
bake: correctly match error when parsing definition

### DIFF
--- a/src/buildx/bake.ts
+++ b/src/buildx/bake.ts
@@ -77,7 +77,7 @@ export class Bake {
       silent: true
     }).then(res => {
       if (res.stderr.length > 0 && res.exitCode != 0) {
-        throw new Error(res.stderr);
+        throw new Error(`cannot parse bake definitions: ${res.stderr.match(/(.*)\s*$/)?.[0]?.trim() ?? 'unknown error'}`);
       }
       return <BakeDefinition>JSON.parse(res.stdout.trim());
     });


### PR DESCRIPTION
related to https://github.com/docker/bake-action/actions/runs/7274951418/job/19821919843#step:6:120

Currently when parsing definitions fails it would return an error but not on the correct line:

![image](https://github.com/docker/actions-toolkit/assets/1951866/b27c2cec-eaca-4937-b835-2633d782ae09)

```
Error: #1 [internal] load local bake definitions
#1 reading ./test/config.hcl 623B / 623B done
#1 reading . 0B / 4.10kB done
#1 DONE 0.0s
ERROR: read .: is a directory
```

This change ensures we return the right line (here `read .: is a directory`) like we do in bake-action and build-push-action: https://github.com/docker/bake-action/blob/52a1696536aaa8818afd3753a71ec46298b8a19b/src/main.ts#L89