### PR TITLE
proof of concept: move saveCache to the post-action phase

### DIFF
--- a/src/buildx/install.ts
+++ b/src/buildx/install.ts
@@ -330,8 +330,8 @@ class InstallCache {
     core.debug(`InstallCache.save cached to hosted tool cache ${htcPath}`);
 
     if (cache.isFeatureAvailable()) {
-      core.debug(`InstallCache.save caching ${this.ghaCacheKey} to GitHub Actions cache`);
-      await cache.saveCache([this.cacheDir], this.ghaCacheKey);
+      core.debug(`InstallCache.save sending ${this.ghaCacheKey} to cache in post-action`);
+      core.saveState('post-save-cache', JSON.stringify({dir: this.cacheDir, key: this.ghaCacheKey}));
     }
 
     return cachePath;


### PR DESCRIPTION
i mocked this up while investigating
https://github.com/docker/setup-buildx-action/issues/293

i guess this is SLIGHTLY better in that it makes the 2 minutes pause
that i'm seeing happen AFTER tests, but the pause is still there.

Signed-off-by: Nick Santos <nick.santos@docker.com>
