### PR TITLE
bump actions/download-artifact to v4

### DIFF
--- a/.github/workflows/buildx-lab-releases-json.yml
+++ b/.github/workflows/buildx-lab-releases-json.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   generate:
-    uses: crazy-max/.github/.github/workflows/releases-json.yml@6dc31870ca6c4f8489bf5a408ab38fae60f47eec
+    uses: crazy-max/.github/.github/workflows/releases-json.yml@fa6141aedf23596fb8bdcceab9cce8dadaa31bd9
     with:
       repository: docker/buildx-desktop
       artifact_name: buildx-lab-releases-json
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4
       -
         name: Download
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: buildx-lab-releases-json
           path: .github

--- a/.github/workflows/buildx-releases-json.yml
+++ b/.github/workflows/buildx-releases-json.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   generate:
-    uses: crazy-max/.github/.github/workflows/releases-json.yml@6dc31870ca6c4f8489bf5a408ab38fae60f47eec
+    uses: crazy-max/.github/.github/workflows/releases-json.yml@fa6141aedf23596fb8bdcceab9cce8dadaa31bd9
     with:
       repository: docker/buildx
       artifact_name: buildx-releases-json
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4
       -
         name: Download
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: buildx-releases-json
           path: .github

--- a/.github/workflows/docker-releases-json.yml
+++ b/.github/workflows/docker-releases-json.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   generate:
-    uses: crazy-max/.github/.github/workflows/releases-json.yml@6dc31870ca6c4f8489bf5a408ab38fae60f47eec
+    uses: crazy-max/.github/.github/workflows/releases-json.yml@fa6141aedf23596fb8bdcceab9cce8dadaa31bd9
     with:
       repository: moby/moby
       artifact_name: docker-releases-json
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4
       -
         name: Download
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: docker-releases-json
           path: .github


### PR DESCRIPTION
Missing bump of `actions/download-artifact`. Needs to bump `crazy-max/.github/.github/workflows/releases-json.yml` as well for artifact v4 support.