### PR TITLE
buildx: ghaNoCache opt for download/build to disable binary cache

### DIFF
--- a/__tests__/buildx/install.test.ts
+++ b/__tests__/buildx/install.test.ts
@@ -67,6 +67,17 @@ describe('download', () => {
     expect(fs.existsSync(toolPath)).toBe(true);
   });
 
+  // prettier-ignore
+  test.each([
+    ['v0.11.2'],
+    ['v0.12.0'],
+  ])(
+  'acquires %p of buildx without cache', async (version) => {
+    const install = new Install({standalone: false});
+    const toolPath = await install.download(version, true);
+    expect(fs.existsSync(toolPath)).toBe(true);
+  });
+
   // TODO: add tests for arm
   // prettier-ignore
   test.each([

--- a/src/buildx/install.ts
+++ b/src/buildx/install.ts
@@ -47,10 +47,11 @@ export class Install {
 
   /*
    * Download buildx binary from GitHub release
-   * @param version semver version or latest
+   * @param v: version semver version or latest
+   * @param ghaNoCache: disable binary caching in GitHub Actions cache backend
    * @returns path to the buildx binary
    */
-  public async download(v: string): Promise<string> {
+  public async download(v: string, ghaNoCache?: boolean): Promise<string> {
     const version: DownloadVersion = await Install.getDownloadVersion(v);
     core.debug(`Install.download version: ${version.version}`);
 
@@ -69,7 +70,8 @@ export class Install {
       htcName: version.key != 'official' ? `buildx-dl-bin-${version.key}` : 'buildx-dl-bin',
       htcVersion: vspec,
       baseCacheDir: path.join(Buildx.configDir, '.bin'),
-      cacheFile: os.platform() == 'win32' ? 'docker-buildx.exe' : 'docker-buildx'
+      cacheFile: os.platform() == 'win32' ? 'docker-buildx.exe' : 'docker-buildx',
+      ghaNoCache: ghaNoCache
     });
 
     const cacheFoundPath = await installCache.find();
@@ -91,10 +93,11 @@ export class Install {
 
   /*
    * Build buildx binary from source
-   * @param gitContext git repo context
+   * @param gitContext: git repo context
+   * @param ghaNoCache: disable binary caching in GitHub Actions cache backend
    * @returns path to the buildx binary
    */
-  public async build(gitContext: string): Promise<string> {
+  public async build(gitContext: string, ghaNoCache?: boolean): Promise<string> {
     const vspec = await this.vspec(gitContext);
     core.debug(`Install.build vspec: ${vspec}`);
 
@@ -102,7 +105,8 @@ export class Install {
       htcName: 'buildx-build-bin',
       htcVersion: vspec,
       baseCacheDir: path.join(Buildx.configDir, '.bin'),
-      cacheFile: os.platform() == 'win32' ? 'docker-buildx.exe' : 'docker-buildx'
+      cacheFile: os.platform() == 'win32' ? 'docker-buildx.exe' : 'docker-buildx',
+      ghaNoCache: ghaNoCache
     });
 
     const cacheFoundPath = await installCache.find();


### PR DESCRIPTION
related to https://github.com/docker/setup-buildx-action/issues/293

Adds `ghaNoCache` opt to `download` and `build` methods for buildx install. This is to allow users to opt-out caching in GitHub actions cache backend.