### PR TITLE
builder: update inspect command parsing

### DIFF
--- a/__tests__/buildx/builder.test.ts
+++ b/__tests__/buildx/builder.test.ts
@@ -393,7 +393,65 @@ describe('parseInspect', () => {
           }
         ],
       }
-    ]
+    ],
+    [
+     'inspect11.txt',
+     {
+       "name": "builder",
+       "driver": "docker-container",
+       "lastActivity": new Date("2024-03-01T14:25:03.000Z"),
+       "nodes": [
+         {
+           "buildkit": "37657a1",
+           "buildkitd-flags": "--debug --allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host --allow-insecure-entitlement=network.host",
+           "driver-opts": [
+             "env.JAEGER_TRACE=localhost:6831",
+             "image=moby/buildkit:master",
+             "network=host",
+             "env.BUILDKIT_STEP_LOG_MAX_SIZE=10485760",
+             "env.BUILDKIT_STEP_LOG_MAX_SPEED=10485760",
+           ],
+           "endpoint": "unix:///var/run/docker.sock",
+           "name": "builder0",
+           "platforms": "linux/amd64,linux/amd64/v2,linux/amd64/v3,linux/arm64,linux/riscv64,linux/ppc64le,linux/s390x,linux/386,linux/mips64le,linux/mips64,linux/arm/v7,linux/arm/v6",
+           "status": "running",
+           "labels": {
+             "org.mobyproject.buildkit.worker.executor": "oci",
+             "org.mobyproject.buildkit.worker.hostname": "docker-desktop",
+             "org.mobyproject.buildkit.worker.network": "host",
+             "org.mobyproject.buildkit.worker.oci.process-mode": "sandbox",
+             "org.mobyproject.buildkit.worker.selinux.enabled": "false",
+             "org.mobyproject.buildkit.worker.snapshotter": "overlayfs",
+           },
+           "gcPolicy": [
+             {
+               "all": false,
+               "filter": [
+                 "type==source.local",
+                 "type==exec.cachemount",
+                 "type==source.git.checkout"
+               ],
+               "keepDuration": "48h0m0s",
+               "keepBytes": "488.3MiB",
+             },
+             {
+               "all": false,
+               "keepDuration": "1440h0m0s",
+               "keepBytes": "94.06GiB",
+             },
+             {
+               "all": false,
+               "keepBytes": "94.06GiB",
+             },
+             {
+               "all": true,
+               "keepBytes": "94.06GiB",
+             }
+           ]
+         }
+       ]
+     }
+    ],
   ])('given %p', async (inspectFile, expected) => {
     expect(await Builder.parseInspect(fs.readFileSync(path.join(fixturesDir, inspectFile)).toString())).toEqual(expected);
   });

--- a/__tests__/buildx/builder.test.ts
+++ b/__tests__/buildx/builder.test.ts
@@ -415,6 +415,12 @@ describe('parseInspect', () => {
            "name": "builder0",
            "platforms": "linux/amd64,linux/amd64/v2,linux/amd64/v3,linux/arm64,linux/riscv64,linux/ppc64le,linux/s390x,linux/386,linux/mips64le,linux/mips64,linux/arm/v7,linux/arm/v6",
            "status": "running",
+           "features": {
+             "Cache export": true,
+             "Docker exporter": true,
+             "Multi-platform build": true,
+             "OCI exporter": true,
+           },
            "labels": {
              "org.mobyproject.buildkit.worker.executor": "oci",
              "org.mobyproject.buildkit.worker.hostname": "docker-desktop",

--- a/__tests__/fixtures/inspect11.txt
+++ b/__tests__/fixtures/inspect11.txt
@@ -1,0 +1,34 @@
+Name:          builder
+Driver:        docker-container
+Last Activity: 2024-03-01 14:25:03 +0000 UTC
+
+Nodes:
+Name:                  builder0
+Endpoint:              unix:///var/run/docker.sock
+Driver Options:        env.JAEGER_TRACE="localhost:6831" image="moby/buildkit:master" network="host" env.BUILDKIT_STEP_LOG_MAX_SIZE="10485760" env.BUILDKIT_STEP_LOG_MAX_SPEED="10485760"
+Status:                running
+BuildKit daemon flags: --debug --allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host --allow-insecure-entitlement=network.host
+BuildKit version:      37657a1
+Platforms:             linux/amd64, linux/amd64/v2, linux/amd64/v3, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/mips64le, linux/mips64, linux/arm/v7, linux/arm/v6
+Labels:
+ org.mobyproject.buildkit.worker.executor:         oci
+ org.mobyproject.buildkit.worker.hostname:         docker-desktop
+ org.mobyproject.buildkit.worker.network:          host
+ org.mobyproject.buildkit.worker.oci.process-mode: sandbox
+ org.mobyproject.buildkit.worker.selinux.enabled:  false
+ org.mobyproject.buildkit.worker.snapshotter:      overlayfs
+GC Policy rule#0:
+ All:           false
+ Filters:       type==source.local,type==exec.cachemount,type==source.git.checkout
+ Keep Duration: 48h0m0s
+ Keep Bytes:    488.3MiB
+GC Policy rule#1:
+ All:           false
+ Keep Duration: 1440h0m0s
+ Keep Bytes:    94.06GiB
+GC Policy rule#2:
+ All:        false
+ Keep Bytes: 94.06GiB
+GC Policy rule#3:
+ All:        true
+ Keep Bytes: 94.06GiB

--- a/__tests__/fixtures/inspect11.txt
+++ b/__tests__/fixtures/inspect11.txt
@@ -10,6 +10,11 @@ Status:                running
 BuildKit daemon flags: --debug --allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host --allow-insecure-entitlement=network.host
 BuildKit version:      37657a1
 Platforms:             linux/amd64, linux/amd64/v2, linux/amd64/v3, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/mips64le, linux/mips64, linux/arm/v7, linux/arm/v6
+Features:
+ Cache export:         true
+ Docker exporter:      true
+ Multi-platform build: true
+ OCI exporter:         true
 Labels:
  org.mobyproject.buildkit.worker.executor:         oci
  org.mobyproject.buildkit.worker.hostname:         docker-desktop

--- a/src/buildx/builder.ts
+++ b/src/buildx/builder.ts
@@ -83,7 +83,7 @@ export class Builder {
         continue;
       }
       switch (true) {
-        case lkey == 'name': {
+        case lkey == 'name':
           parsingType = undefined;
           if (builder.name == undefined) {
             builder.name = value;
@@ -98,42 +98,36 @@ export class Builder {
             currentNode = {name: value};
           }
           break;
-        }
-        case lkey == 'driver': {
+        case lkey == 'driver':
           parsingType = undefined;
           builder.driver = value;
           break;
-        }
-        case lkey == 'last activity': {
+        case lkey == 'last activity':
           parsingType = undefined;
           builder.lastActivity = new Date(value);
           break;
-        }
-        case lkey == 'endpoint': {
+        case lkey == 'endpoint':
           parsingType = undefined;
           currentNode.endpoint = value;
           break;
-        }
-        case lkey == 'driver options': {
+        case lkey == 'driver options':
           parsingType = undefined;
           currentNode['driver-opts'] = (value.match(/([a-zA-Z0-9_.]+)="([^"]*)"/g) || []).map(v => v.replace(/^(.*)="(.*)"$/g, '$1=$2'));
           break;
-        }
-        case lkey == 'status': {
+        case lkey == 'status':
           parsingType = undefined;
           currentNode.status = value;
           break;
-        }
-        case lkey == 'flags': {
+        case lkey == 'buildkit daemon flags':
+        case lkey == 'flags': // buildx < v0.13
           parsingType = undefined;
           currentNode['buildkitd-flags'] = value;
           break;
-        }
-        case lkey == 'buildkit': {
+        case lkey == 'buildkit version':
+        case lkey == 'buildkit': // buildx < v0.13
           parsingType = undefined;
           currentNode.buildkit = value;
           break;
-        }
         case lkey == 'platforms': {
           parsingType = undefined;
           if (!value) {
@@ -155,19 +149,17 @@ export class Builder {
           currentNode.platforms = platforms.join(',');
           break;
         }
-        case lkey == 'labels': {
+        case lkey == 'labels':
           parsingType = 'label';
           currentNode.labels = {};
           break;
-        }
-        case lkey.startsWith('gc policy rule#'): {
+        case lkey.startsWith('gc policy rule#'):
           parsingType = 'gcpolicy';
           if (currentNode.gcPolicy && currentGCPolicy) {
             currentNode.gcPolicy.push(currentGCPolicy);
             currentGCPolicy = undefined;
           }
           break;
-        }
         default: {
           switch (parsingType || '') {
             case 'label': {

--- a/src/buildx/builder.ts
+++ b/src/buildx/builder.ts
@@ -149,6 +149,10 @@ export class Builder {
           currentNode.platforms = platforms.join(',');
           break;
         }
+        case lkey == 'features':
+          parsingType = 'features';
+          currentNode.features = {};
+          break;
         case lkey == 'labels':
           parsingType = 'label';
           currentNode.labels = {};
@@ -162,6 +166,11 @@ export class Builder {
           break;
         default: {
           switch (parsingType || '') {
+            case 'features': {
+              currentNode.features = currentNode.features || {};
+              currentNode.features[key.trim()] = Boolean(value);
+              break;
+            }
             case 'label': {
               currentNode.labels = currentNode.labels || {};
               currentNode.labels[key.trim()] = value;

--- a/src/buildx/builder.ts
+++ b/src/buildx/builder.ts
@@ -56,10 +56,19 @@ export class Builder {
   }
 
   public async inspect(name: string): Promise<BuilderInfo> {
+    // always enable debug for inspect command, so we can display additional
+    // fields such as features: https://github.com/docker/buildx/pull/1854
+    const envs = Object.assign({}, process.env, {
+      DEBUG: '1'
+    }) as {
+      [key: string]: string;
+    };
+
     const cmd = await this.buildx.getCommand(['inspect', name]);
     return await Exec.getExecOutput(cmd.command, cmd.args, {
       ignoreReturnCode: true,
-      silent: true
+      silent: true,
+      env: envs
     }).then(res => {
       if (res.stderr.length > 0 && res.exitCode != 0) {
         throw new Error(res.stderr.trim());

--- a/src/types/builder.ts
+++ b/src/types/builder.ts
@@ -32,6 +32,7 @@ export interface Node {
 export interface NodeInfo extends Node {
   status?: string;
   buildkit?: string;
+  features?: Record<string, boolean>;
   labels?: Record<string, string>;
   gcPolicy?: Array<GCPolicy>;
 }


### PR DESCRIPTION
follow-up https://github.com/docker/buildx/pull/2268, https://github.com/docker/buildx/pull/1854
related to https://github.com/docker/buildx/issues/2325#issuecomment-1985424880

Since Buildx 0.13, some keys have been renamed for `buildx inspect` command: https://github.com/docker/buildx/pull/2268/files#diff-201694404c6fd5e0d301670e34752d92835c43f21dc8e59e342b80a26848ec6fR87-R91

Also adds support for https://github.com/docker/buildx/pull/1854 available since Buildx 0.11.