### PR TITLE
cache: run cache.post in core.group

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -103,7 +103,7 @@ export class Cache {
   public static async post(): Promise<CachePostState | undefined> {
     const state = core.getState(Cache.POST_CACHE_KEY);
     if (!state) {
-      core.debug(`Cache.post no state`);
+      core.info(`State not set`);
       return Promise.resolve(undefined);
     }
     let cacheState: CachePostState;

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,8 @@ export async function run(main: () => Promise<void>, post?: () => Promise<void>)
     if (post) {
       await post();
     }
-    await Cache.post();
+    await core.group(`Post cache`, async () => {
+      await Cache.post();
+    });
   }
 }


### PR DESCRIPTION
follow-up https://github.com/docker/setup-buildx-action/actions/runs/8299720155/job/22716669682#step:7:44

It's better to group cache logs to avoid it being mixed with other post steps.