### PR TITLE
bake: additional opts when parsing definition

### DIFF
--- a/__tests__/buildx/bake.test.itg.ts
+++ b/__tests__/buildx/bake.test.itg.ts
@@ -29,17 +29,20 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-maybe('parseDefinitions', () => {
+maybe('getDefinition', () => {
   // prettier-ignore
   test.each([
     [
-      ['https://github.com/docker/buildx.git#v0.10.4'],
+      'https://github.com/docker/buildx.git#v0.10.4',
       ['binaries-cross'],
       path.join(fixturesDir, 'bake-buildx-0.10.4-binaries-cross.json')
-    ]
-  ])('given %p', async (sources: string[], targets: string[], out: string) => {
+    ],
+  ])('given %p', async (source: string, targets: string[], out: string) => {
     const bake = new Bake();
     const expectedDef = <BakeDefinition>JSON.parse(fs.readFileSync(out, {encoding: 'utf-8'}).trim())
-    expect(await bake.parseDefinitions(sources, targets)).toEqual(expectedDef);
+    expect(await bake.getDefinition({
+      source: source,
+      targets: targets
+    })).toEqual(expectedDef);
   });
 });

--- a/__tests__/buildx/bake.test.ts
+++ b/__tests__/buildx/bake.test.ts
@@ -19,6 +19,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import {Bake} from '../../src/buildx/bake';
+
+import {ExecOptions} from '@actions/exec';
 import {BakeDefinition} from '../../src/types/bake';
 
 const fixturesDir = path.join(__dirname, '..', 'fixtures');
@@ -27,31 +29,38 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-describe('parseDefinitions', () => {
+describe('getDefinition', () => {
   // prettier-ignore
   test.each([
     [
       [path.join(fixturesDir, 'bake-01.hcl')],
       ['validate'],
       [],
+      {silent: true},
       path.join(fixturesDir, 'bake-01-validate.json')
     ],
     [
       [path.join(fixturesDir, 'bake-02.hcl')],
       ['build'],
       [],
+      undefined,
       path.join(fixturesDir, 'bake-02-build.json')
     ],
     [
       [path.join(fixturesDir, 'bake-01.hcl')],
       ['image'],
       ['*.output=type=docker', '*.platform=linux/amd64'],
+      undefined,
       path.join(fixturesDir, 'bake-01-overrides.json')
     ]
-  ])('given %p', async (sources: string[], targets: string[], overrides: string[], out: string) => {
+  ])('given %p', async (files: string[], targets: string[], overrides: string[], execOptions: ExecOptions | undefined, out: string) => {
     const bake = new Bake();
     const expectedDef = <BakeDefinition>JSON.parse(fs.readFileSync(out, {encoding: 'utf-8'}).trim())
-    expect(await bake.parseDefinitions(sources, targets, overrides)).toEqual(expectedDef);
+    expect(await bake.getDefinition({
+      files: files,
+      targets: targets,
+      overrides: overrides
+    }, execOptions)).toEqual(expectedDef);
   });
 });
 

--- a/src/types/bake.ts
+++ b/src/types/bake.ts
@@ -39,7 +39,9 @@ export interface Target {
   platforms?: Array<string>;
   pull?: boolean;
   secret?: Array<string>;
+  'shm-size'?: string;
   ssh?: Array<string>;
   tags?: Array<string>;
   target?: string;
+  ulimits?: Array<string>;
 }


### PR DESCRIPTION
`provenance`, `sbom` and `no-cache` opts were missing when parsing the definition. `shm-size` and `ulimits` attributes have been added to `Target` struct as well related to https://github.com/docker/buildx/pull/2242

Also adds `execOptions` opt that will be used in bake-action to handle specific options accordingly. This is related to https://github.com/docker/bake-action/pull/193 where I was testing loading a remote bake definition from a private repo which doesn't give enough context when failing due to `silent: true`.