### PR TITLE
bake: handle git auth token when parsing remote definition

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ on:
 
 env:
   NODE_VERSION: "20"
+  BUILDX_VERSION: "v0.14.0-rc1"
 
 jobs:
   test:
@@ -102,6 +103,13 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'yarn'
+      -
+        name: Set up Docker Buildx
+        if: startsWith(matrix.os, 'ubuntu')
+        uses: docker/setup-buildx-action@v3
+        with:
+          version: ${{ env.BUILDX_VERSION }}
+          driver: docker
       -
         name: Install
         run: yarn install

--- a/__tests__/buildx/bake.test.itg.ts
+++ b/__tests__/buildx/bake.test.itg.ts
@@ -35,14 +35,28 @@ maybe('getDefinition', () => {
     [
       'https://github.com/docker/buildx.git#v0.10.4',
       ['binaries-cross'],
-      path.join(fixturesDir, 'bake-buildx-0.10.4-binaries-cross.json')
+      path.join(fixturesDir, 'bake-buildx-0.10.4-binaries-cross.json'),
+      false,
     ],
-  ])('given %p', async (source: string, targets: string[], out: string) => {
+    // TODO: uncomment this test case when we have access to the private repo using an access token
+    // [
+    //   'https://github.com/docker/test-docker-action.git#remote-private',
+    //   ['default'],
+    //   path.join(fixturesDir, 'bake-test-docker-action-remote-private.json'),
+    //   true,
+    // ]
+  ])('given %p', async (source: string, targets: string[], out: string, auth) => {
+    const gitAuthToken = process.env.GITHUB_TOKEN || '';
+    if (auth && !gitAuthToken) {
+      console.log(`Git auth token not available, skipping test`);
+      return;
+    }
     const bake = new Bake();
     const expectedDef = <BakeDefinition>JSON.parse(fs.readFileSync(out, {encoding: 'utf-8'}).trim())
     expect(await bake.getDefinition({
       source: source,
-      targets: targets
+      targets: targets,
+      githubToken: gitAuthToken,
     })).toEqual(expectedDef);
   });
 });

--- a/__tests__/fixtures/bake-test-docker-action-remote-private.json
+++ b/__tests__/fixtures/bake-test-docker-action-remote-private.json
@@ -1,0 +1,11 @@
+{
+  "target": {
+    "default": {
+      "context": "https://github.com/docker/test-docker-action.git#remote-private",
+      "dockerfile": "Dockerfile",
+      "tags": [
+        "foo"
+      ]
+    }
+  }
+}

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -16,7 +16,7 @@
 
 ARG NODE_VERSION=20
 ARG DOCKER_VERSION=26.0.0
-ARG BUILDX_VERSION=0.13.1
+ARG BUILDX_VERSION=0.14.0-rc1
 
 FROM node:${NODE_VERSION}-alpine AS base
 RUN apk add --no-cache cpio findutils git

--- a/src/buildx/bake.ts
+++ b/src/buildx/bake.ts
@@ -36,6 +36,8 @@ export interface BakeCmdOpts {
   sbom?: string;
   source?: string;
   targets?: Array<string>;
+
+  githubToken?: string; // for auth with remote definitions on private repos
 }
 
 export class Bake {
@@ -48,6 +50,13 @@ export class Bake {
   public async getDefinition(cmdOpts: BakeCmdOpts, execOptions?: ExecOptions): Promise<BakeDefinition> {
     execOptions = execOptions || {ignoreReturnCode: true};
     execOptions.ignoreReturnCode = true;
+    if (cmdOpts.githubToken) {
+      execOptions.env = Object.assign({}, process.env, {
+        BUILDX_BAKE_GIT_AUTH_TOKEN: cmdOpts.githubToken
+      }) as {
+        [key: string]: string;
+      };
+    }
 
     const args = ['bake'];
 

--- a/src/buildx/inputs.ts
+++ b/src/buildx/inputs.ts
@@ -77,24 +77,23 @@ export class Inputs {
   }
 
   public static resolveBuildSecretString(kvp: string): string {
-    return Inputs.resolveBuildSecret(kvp, false);
+    const [key, file] = Inputs.resolveBuildSecret(kvp, false);
+    return `id=${key},src=${file}`;
   }
 
   public static resolveBuildSecretFile(kvp: string): string {
-    return Inputs.resolveBuildSecret(kvp, true);
+    const [key, file] = Inputs.resolveBuildSecret(kvp, true);
+    return `id=${key},src=${file}`;
   }
 
   public static resolveBuildSecretEnv(kvp: string): string {
     const [key, value] = parseKvp(kvp);
-
     return `id=${key},env=${value}`;
   }
 
-  public static resolveBuildSecret(kvp: string, file: boolean): string {
+  public static resolveBuildSecret(kvp: string, file: boolean): [string, string] {
     const [key, _value] = parseKvp(kvp);
-
     let value = _value;
-
     if (file) {
       if (!fs.existsSync(value)) {
         throw new Error(`secret file ${value} not found`);
@@ -103,7 +102,7 @@ export class Inputs {
     }
     const secretFile = Context.tmpName({tmpdir: Context.tmpDir()});
     fs.writeFileSync(secretFile, value);
-    return `id=${key},src=${secretFile}`;
+    return [key, secretFile];
   }
 
   public static getProvenanceInput(name: string): string {


### PR DESCRIPTION
We got the following output when trying to build from a remote bake definition on a private repo: https://github.com/docker/test-docker-action/tree/remote-private

```
$ docker buildx bake https://github.com/docker/test-docker-action.git#remote-private
#0 building with "default" instance using docker driver

#1 [internal] load git source https://github.com/docker/test-docker-action.git#remote-private
#1 0.225 fatal: could not read Username for 'https://github.com': terminal prompts disabled
#1 ERROR: failed to fetch remote https://github.com/docker/test-docker-action.git: git error: exit status 128
stderr:
fatal: could not read Username for 'https://github.com': terminal prompts disabled

------
 > [internal] load git source https://github.com/docker/test-docker-action.git#remote-private:
0.225 fatal: could not read Username for 'https://github.com': terminal prompts disabled
------
ERROR: couldn't find a bake definition
```

Using a `GIT_AUTH_TOKEN` secret doesn't seem to work:

```
/usr/bin/docker buildx bake https://github.com/docker/test-docker-action.git#remote-private --set *.secrets=id=GIT_AUTH_TOKEN,src=/home/runner/work/_temp/docker-actions-toolkit-Rrz5jT/tmp-1910-aMBJe65r7Kf4 --print default
#0 building with "default" instance using docker driver
#1 [internal] load git source https://github.com/docker/test-docker-action.git#remote-private
#1 0.039 Initialized empty Git repository in /var/lib/docker/overlay2/l763ozu3v99vupy2gmketmi8t/diff/
#1 0.279 fatal: could not read Username for 'https://github.com/': terminal prompts disabled
```

Which makes sense as loading remote bake definitions is done by a dedicated solve request, not during build: https://github.com/docker/buildx/blob/8abef5908705e49f7ba88ef8c957e1127b597a2a/bake/remote.go#L62

https://github.com/docker/buildx/pull/2363 implements git auth token support for remote bake definitions using the `BUILDX_BAKE_GIT_AUTH_TOKEN` env var.