### PR TITLE
docker: fix pull caching

### DIFF
--- a/src/docker/docker.ts
+++ b/src/docker/docker.ts
@@ -136,8 +136,8 @@ export class Docker {
     await Exec.getExecOutput(`docker`, ['pull', image], {
       ignoreReturnCode: true
     }).then(res => {
-      pulled = false;
       if (res.stderr.length > 0 && res.exitCode != 0) {
+        pulled = false;
         const err = res.stderr.match(/(.*)\s*$/)?.[0]?.trim() ?? 'unknown error';
         if (cacheFoundPath) {
           core.warning(`Failed to pull image, using one from cache: ${err}`);


### PR DESCRIPTION
introduced by second commit in https://github.com/docker/actions-toolkit/pull/200/commits/fc4dae47b637c9cec4371287c3e1798d262fa3dd#diff-d7be6b531f5d6821302968cc601218e4d174278b30cb452fca615843b1235f09R138