### PR TITLE
github: set attempts to workflowRunURL

### DIFF
--- a/__mocks__/@actions/github.ts
+++ b/__mocks__/@actions/github.ts
@@ -22,7 +22,8 @@ export const context = {
     repo: 'actions-toolkit'
   },
   ref: 'refs/heads/master',
-  runId: 123,
+  runId: 2188748038,
+  runNumber: 15,
   payload: {
     after: '860c1904a1ce19322e91ac35af1ab07466440c37',
     base_ref: null,

--- a/__tests__/buildx/build.test.ts
+++ b/__tests__/buildx/build.test.ts
@@ -100,7 +100,7 @@ describe('getProvenanceInput', () => {
   test.each([
     [
       'true',
-      'builder-id=https://github.com/docker/actions-toolkit/actions/runs/123'
+      'builder-id=https://github.com/docker/actions-toolkit/actions/runs/2188748038/attempts/2'
     ],
     [
       'false',
@@ -108,11 +108,11 @@ describe('getProvenanceInput', () => {
     ],
     [
       'mode=min',
-      'mode=min,builder-id=https://github.com/docker/actions-toolkit/actions/runs/123'
+      'mode=min,builder-id=https://github.com/docker/actions-toolkit/actions/runs/2188748038/attempts/2'
     ],
     [
       'mode=max',
-      'mode=max,builder-id=https://github.com/docker/actions-toolkit/actions/runs/123'
+      'mode=max,builder-id=https://github.com/docker/actions-toolkit/actions/runs/2188748038/attempts/2'
     ],
     [
       'builder-id=foo',
@@ -137,11 +137,11 @@ describe('resolveProvenanceAttrs', () => {
   test.each([
     [
       'mode=min',
-      'mode=min,builder-id=https://github.com/docker/actions-toolkit/actions/runs/123'
+      'mode=min,builder-id=https://github.com/docker/actions-toolkit/actions/runs/2188748038/attempts/2'
     ],
     [
       'mode=max',
-      'mode=max,builder-id=https://github.com/docker/actions-toolkit/actions/runs/123'
+      'mode=max,builder-id=https://github.com/docker/actions-toolkit/actions/runs/2188748038/attempts/2'
     ],
     [
       'builder-id=foo',
@@ -153,7 +153,7 @@ describe('resolveProvenanceAttrs', () => {
     ],
     [
       '',
-      'builder-id=https://github.com/docker/actions-toolkit/actions/runs/123'
+      'builder-id=https://github.com/docker/actions-toolkit/actions/runs/2188748038/attempts/2'
     ],
   ])('given %p', async (input: string, expected: string) => {
     expect(Build.resolveProvenanceAttrs(input)).toEqual(expected);

--- a/__tests__/github.test.ts
+++ b/__tests__/github.test.ts
@@ -90,8 +90,8 @@ describe('apiURL', () => {
 });
 
 describe('workflowRunURL', () => {
-  it('returns 123', async () => {
-    expect(GitHub.workflowRunURL).toEqual('https://github.com/docker/actions-toolkit/actions/runs/123');
+  it('returns 2188748038', async () => {
+    expect(GitHub.workflowRunURL).toEqual('https://github.com/docker/actions-toolkit/actions/runs/2188748038/attempts/2');
   });
 });
 

--- a/jest.config.itg.ts
+++ b/jest.config.itg.ts
@@ -23,6 +23,9 @@ const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'docker-actions-toolkit-'))
 process.env = Object.assign({}, process.env, {
   TEMP: tmpDir,
   GITHUB_REPOSITORY: 'docker/actions-toolkit',
+  GITHUB_RUN_ATTEMPT: 2,
+  GITHUB_RUN_ID: 2188748038,
+  GITHUB_RUN_NUMBER: 15,
   RUNNER_TEMP: path.join(tmpDir, 'runner-temp'),
   RUNNER_TOOL_CACHE: path.join(tmpDir, 'runner-tool-cache')
 }) as {

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -23,6 +23,9 @@ const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'docker-actions-toolkit-'))
 process.env = Object.assign({}, process.env, {
   TEMP: tmpDir,
   GITHUB_REPOSITORY: 'docker/actions-toolkit',
+  GITHUB_RUN_ATTEMPT: 2,
+  GITHUB_RUN_ID: 2188748038,
+  GITHUB_RUN_NUMBER: 15,
   RUNNER_TEMP: path.join(tmpDir, 'runner-temp'),
   RUNNER_TOOL_CACHE: path.join(tmpDir, 'runner-tool-cache')
 }) as {

--- a/src/github.ts
+++ b/src/github.ts
@@ -65,7 +65,9 @@ export class GitHub {
   }
 
   static get workflowRunURL(): string {
-    return `${GitHub.serverURL}/${github.context.repo.owner}/${github.context.repo.repo}/actions/runs/${github.context.runId}`;
+    const runID = process.env.GITHUB_RUN_ID || github.context.runId;
+    const runAttempt = process.env.GITHUB_RUN_ATTEMPT || 1;
+    return `${GitHub.serverURL}/${github.context.repo.owner}/${github.context.repo.repo}/actions/runs/${runID}/attempts/${runAttempt}`;
   }
 
   static get actionsRuntimeToken(): GitHubActionsRuntimeToken | undefined {


### PR DESCRIPTION
We should set the number of attempts in the workflow run URL otherwise `builder-id` in provenance could be inaccurate.