### PR TITLE
Add a test to define behavior when empty parameters are passed

### DIFF
--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -31,6 +31,12 @@ describe('getInputList', () => {
     expect(res).toEqual(['bar']);
   });
 
+  it('empty correctly', async () => {
+    setInput('foo', '');
+    const res = Util.getInputList('foo');
+    expect(res).toEqual([]);
+  });
+
   it('multiline correctly', async () => {
     setInput('foo', 'bar\nbaz');
     const res = Util.getInputList('foo');


### PR DESCRIPTION
Add a single test to define behavior when an empty string is passed to the input list.

For context, my team was trying to determine a proper default value to set in a re-packaged internal version of docker/build-push-action@v4's `platform` field. We wanted to make this configurable, but wanted to provide a valid default value that wouldn't change behavior as we previously didn't set this. Checking the source, led us here where we didn't find it included in the test spec. Adding this test should make the expected behavior well defined and allow folks to depend on it.