### PR TITLE
buildkit: add types

### DIFF
--- a/src/types/buildkit/buildkit.ts
+++ b/src/types/buildkit/buildkit.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2024 actions-toolkit authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// https://github.com/moby/buildkit/blob/v0.14.0/solver/llbsolver/history.go#L672
+export const MEDIATYPE_STATUS_V0 = 'application/vnd.buildkit.status.v0';

--- a/src/types/buildkit/client.ts
+++ b/src/types/buildkit/client.ts
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2024 actions-toolkit authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Digest} from '../oci/digest';
+import {ProgressGroup, Range, SourceInfo} from './ops';
+
+// https://github.com/moby/buildkit/blob/v0.14.0/client/graph.go#L10-L19
+export interface Vertex {
+  digest?: Digest;
+  inputs?: Array<Digest>;
+  name?: string;
+  started?: Date;
+  completed?: Date;
+  cached?: boolean;
+  error?: string;
+  progressGroup?: ProgressGroup;
+}
+
+// https://github.com/moby/buildkit/blob/v0.14.0/client/graph.go#L21-L30
+export interface VertexStatus {
+  id: string;
+  vertex?: Digest;
+  name?: string;
+  total?: number;
+  current: number;
+  timestamp?: Date;
+  started?: Date;
+  completed?: Date;
+}
+
+// https://github.com/moby/buildkit/blob/v0.14.0/client/graph.go#L32-L37
+export interface VertexLog {
+  vertex?: Digest;
+  stream?: number;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data: any;
+  timestamp: Date;
+}
+
+// https://github.com/moby/buildkit/blob/v0.14.0/client/graph.go#L39-L48
+export interface VertexWarning {
+  vertex?: Digest;
+  level?: number;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  short?: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  detail?: Array<any>;
+  url?: string;
+
+  sourceInfo?: SourceInfo;
+  range?: Array<Range>;
+}
+
+// https://github.com/moby/buildkit/blob/v0.14.0/client/graph.go#L50-L55
+export interface SolveStatus {
+  vertexes?: Array<Vertex>;
+  statuses?: Array<VertexStatus>;
+  logs?: Array<VertexLog>;
+  warnings?: Array<VertexWarning>;
+}
+
+// https://github.com/moby/buildkit/blob/v0.14.0/client/graph.go#L57-L60
+export interface SolveResponse {
+  exporterResponse: Record<string, string>;
+}

--- a/src/types/buildkit/control.ts
+++ b/src/types/buildkit/control.ts
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2024 actions-toolkit authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Descriptor} from '../oci/descriptor';
+import {Digest} from '../oci/digest';
+import {ProgressGroup, Range, SourceInfo} from './ops';
+import {RpcStatus} from './rpc';
+
+// https://github.com/moby/buildkit/blob/v0.14.0/api/services/control/control.pb.go#L1504-L1525
+export interface BuildHistoryRecord {
+  Ref: string;
+  Frontend: string;
+  FrontendAttrs: Record<string, string>;
+  Exporters: Array<Exporter>;
+  error?: RpcStatus;
+  CreatedAt?: Date;
+  CompletedAt?: Date;
+  logs?: Descriptor;
+  ExporterResponse: Record<string, string>;
+  Result?: BuildResultInfo;
+  Results: Record<string, BuildResultInfo>;
+  Generation: number;
+  trace?: Descriptor;
+  pinned: boolean;
+  numCachedSteps: number;
+  numTotalSteps: number;
+  numCompletedSteps: number;
+}
+
+// https://github.com/moby/buildkit/blob/v0.14.0/api/services/control/control.pb.go#L1909-L1917
+export interface Exporter {
+  Type: string;
+  Attrs: Record<string, string>;
+}
+
+// https://github.com/moby/buildkit/blob/v0.14.0/api/services/control/control.pb.go#L1845-L1852
+export interface BuildResultInfo {
+  ResultDeprecated?: Descriptor;
+  Attestations?: Array<Descriptor>;
+  Results?: Record<number, Descriptor>;
+}
+
+// https://github.com/moby/buildkit/blob/v0.14.0/api/services/control/control.pb.go#L751-L759
+export interface StatusResponse {
+  vertexes?: Array<Vertex>;
+  statuses?: Array<VertexStatus>;
+  logs?: Array<VertexLog>;
+  warnings?: Array<VertexWarning>;
+}
+
+// https://github.com/moby/buildkit/blob/v0.14.0/api/services/control/control.pb.go#L822-L834
+export interface Vertex {
+  digest: Digest;
+  inputs: Array<Digest>;
+  name?: string;
+  cached?: boolean;
+  started?: Date;
+  completed?: Date;
+  error?: string;
+  progressGroup?: ProgressGroup;
+}
+
+// https://github.com/moby/buildkit/blob/v0.14.0/api/services/control/control.pb.go#L911-L923
+export interface VertexStatus {
+  ID?: string;
+  vertex: Digest;
+  name?: string;
+  current?: number;
+  total?: number;
+  timestamp: Date;
+  started?: Date;
+  completed?: Date;
+}
+
+// https://github.com/moby/buildkit/blob/v0.14.0/api/services/control/control.pb.go#L1007-L1015
+export interface VertexLog {
+  vertex: Digest;
+  timestamp: Date;
+  stream?: number;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  msg?: any;
+}
+
+// https://github.com/moby/buildkit/blob/v0.14.0/api/services/control/control.pb.go#L1071-L1082
+export interface VertexWarning {
+  vertex: Digest;
+  level?: number;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  short?: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  detail?: Array<any>;
+  url?: string;
+  info?: SourceInfo;
+  ranges?: Array<Range>;
+}

--- a/src/types/buildkit/ops.ts
+++ b/src/types/buildkit/ops.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2024 actions-toolkit authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// https://github.com/moby/buildkit/blob/v0.14.0/solver/pb/ops.pb.go#L1901-L1909
+export interface Definition {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  def?: Array<any>;
+  metadata: Record<string, OpMetadata>;
+  Source?: Source;
+}
+
+// https://github.com/moby/buildkit/blob/v0.14.0/solver/pb/ops.pb.go#L1313-L1323
+export interface OpMetadata {
+  ignore_cache?: boolean;
+  description?: Record<string, string>;
+  export_cache?: ExportCache;
+  caps: Record<string, boolean>;
+  progress_group?: ProgressGroup;
+}
+
+// https://github.com/moby/buildkit/blob/v0.14.0/solver/pb/ops.pb.go#L1390-L1393
+export interface Source {
+  locations?: Record<string, Locations>;
+  infos?: Array<SourceInfo>;
+}
+
+// https://github.com/moby/buildkit/blob/v0.14.0/solver/pb/ops.pb.go#L1439-L1441
+export interface Locations {
+  locations?: Array<Location>;
+}
+
+// https://github.com/moby/buildkit/blob/v0.14.0/solver/pb/ops.pb.go#L1545-L1548
+export interface Location {
+  sourceIndex?: number;
+  ranges?: Array<Range>;
+}
+
+// https://github.com/moby/buildkit/blob/v0.14.0/solver/pb/ops.pb.go#L1594-L1597
+export interface Range {
+  start: Position;
+  end: Position;
+}
+
+// https://github.com/moby/buildkit/blob/v0.14.0/solver/pb/ops.pb.go#L1643-L1646
+export interface Position {
+  line: number;
+  character: number;
+}
+
+// https://github.com/moby/buildkit/blob/v0.14.0/solver/pb/ops.pb.go#L1480-L1485
+export interface SourceInfo {
+  filename?: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data?: any;
+  definition?: Definition;
+  language?: string;
+}
+
+// https://github.com/moby/buildkit/blob/v0.14.0/solver/pb/ops.pb.go#L1691-L1693
+export interface ExportCache {
+  Value?: boolean;
+}
+
+// https://github.com/moby/buildkit/blob/v0.14.0/solver/pb/ops.pb.go#L1731-L1735
+export interface ProgressGroup {
+  id?: string;
+  name?: string;
+  weak?: boolean;
+}

--- a/src/types/buildkit/rpc.ts
+++ b/src/types/buildkit/rpc.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2024 actions-toolkit authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// https://github.com/moby/buildkit/blob/v0.14.0/vendor/github.com/gogo/googleapis/google/rpc/status.pb.go#L36-L49
+export interface RpcStatus {
+  code: number;
+  message: string;
+  details: Array<RpcAny>;
+}
+
+// https://github.com/moby/buildkit/blob/v0.14.0/vendor/github.com/gogo/protobuf/types/any.pb.go#L108-L143
+// Define properties based on google.protobuf.Any. For simplicity, assuming it
+// has at least a type_url and a value.
+export interface RpcAny {
+  type_url: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  value: any;
+}


### PR DESCRIPTION
Adds BuildKit types that will be used in #302 (related to https://github.com/docker/buildx/pull/2511) and #347.

Atm these types are manually crafted based on generated proto from BuildKit repository:
* https://github.com/moby/buildkit/blob/v0.14.0/api/services/control/control.pb.go
* https://github.com/moby/buildkit/blob/v0.14.0/solver/pb/ops.pb.go
* https://github.com/moby/buildkit/blob/v0.14.0/vendor/github.com/gogo/googleapis/google/rpc/status.pb.go
* https://github.com/moby/buildkit/blob/v0.14.0/vendor/github.com/gogo/protobuf/types/any.pb.go

In follow-up we should generate these types with a tool like https://github.com/stephenh/ts-proto.

@nico1510 @austin5456 let me know if this is something that could be used on DD side by either using the actions-toolkit module: https://www.npmjs.com/package/@docker/actions-toolkit or having a dedicated one like `@types/buildkit` in https://github.com/DefinitelyTyped/DefinitelyTyped.