### PR TITLE
github(summary): use relative path for artifact link and fix filename

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,6 +149,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CTN_BUILDER_NAME: ${{ steps.builder.outputs.name }}
+          TEST_FOR_SUMMARY: ${{ secrets.TEST_FOR_SUMMARY }}
       -
         name: Check coverage
         run: |

--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -353,6 +353,33 @@ describe('generateRandomString', () => {
   });
 });
 
+describe('stringToUnicodeEntities', () => {
+  it('should convert a string to Unicode entities', () => {
+    const input = 'Hello, World!';
+    const expected = '&#x48;&#x65;&#x6c;&#x6c;&#x6f;&#x2c;&#x20;&#x57;&#x6f;&#x72;&#x6c;&#x64;&#x21;';
+    const result = Util.stringToUnicodeEntities(input);
+    expect(result).toEqual(expected);
+  });
+  it('should handle an empty string', () => {
+    const input = '';
+    const expected = '';
+    const result = Util.stringToUnicodeEntities(input);
+    expect(result).toEqual(expected);
+  });
+  it('should handle special characters', () => {
+    const input = '@#^&*()';
+    const expected = '&#x40;&#x23;&#x5e;&#x26;&#x2a;&#x28;&#x29;';
+    const result = Util.stringToUnicodeEntities(input);
+    expect(result).toEqual(expected);
+  });
+  it('should handle non-English characters', () => {
+    const input = 'こんにちは';
+    const expected = '&#x3053;&#x3093;&#x306b;&#x3061;&#x306f;';
+    const result = Util.stringToUnicodeEntities(input);
+    expect(result).toEqual(expected);
+  });
+});
+
 // See: https://github.com/actions/toolkit/blob/a1b068ec31a042ff1e10a522d8fdf0b8869d53ca/packages/core/src/core.ts#L89
 function getInputName(name: string): string {
   return `INPUT_${name.replace(/ /g, '_').toUpperCase()}`;

--- a/src/github.ts
+++ b/src/github.ts
@@ -68,10 +68,18 @@ export class GitHub {
     return `${github.context.repo.owner}/${github.context.repo.repo}`;
   }
 
-  public static workflowRunURL(setAttempts?: boolean): string {
+  static get runId(): number {
+    return process.env.GITHUB_RUN_ID ? +process.env.GITHUB_RUN_ID : github.context.runId;
+  }
+
+  static get runAttempt(): number {
     // TODO: runAttempt is not yet part of github.context but will be in a
     //  future release of @actions/github package: https://github.com/actions/toolkit/commit/faa425440f86f9c16587a19dfb59491253a2c92a
-    return `${GitHub.serverURL}/${GitHub.repository}/actions/runs/${github.context.runId}${setAttempts ? `/attempts/${process.env.GITHUB_RUN_ATTEMPT || 1}` : ''}`;
+    return process.env.GITHUB_RUN_ATTEMPT ? +process.env.GITHUB_RUN_ATTEMPT : 1;
+  }
+
+  public static workflowRunURL(setAttempts?: boolean): string {
+    return `${GitHub.serverURL}/${GitHub.repository}/actions/runs/${GitHub.runId}${setAttempts ? `/attempts/${GitHub.runAttempt}` : ''}`;
   }
 
   static get actionsRuntimeToken(): GitHubActionsRuntimeToken | undefined {
@@ -211,6 +219,14 @@ export class GitHub {
 
     const refsSize = Object.keys(opts.exportRes.refs).length;
 
+    // we just need the last two parts of the URL as they are always relative
+    // to the workflow run URL otherwise URL could be broken if GitHub
+    // repository name is part of a secret value used in the workflow. e.g.:
+    //  artifact: https://github.com/docker/actions-toolkit/actions/runs/9552208295/artifacts/1609622746
+    //  workflow: https://github.com/docker/actions-toolkit/actions/runs/9552208295
+    // https://github.com/docker/actions-toolkit/issues/367
+    const artifactRelativeURL = `./${GitHub.runId}/${opts.uploadRes.url.split('/').slice(-2).join('/')}`;
+
     // prettier-ignore
     const sum = core.summary
       .addHeading('Docker Build summary', 1)
@@ -221,7 +237,7 @@ export class GitHub {
         .addRaw(addLink('Learn more', 'https://docs.docker.com/go/build-summary/'))
       .addRaw('</p>')
       .addRaw(`<p>`)
-        .addRaw(`:arrow_down: ${addLink(`<strong>${opts.uploadRes.filename}</strong>`, opts.uploadRes.url)} (${Util.formatFileSize(opts.uploadRes.size)})`)
+        .addRaw(`:arrow_down: ${addLink(`<strong>${opts.uploadRes.filename}</strong>`, artifactRelativeURL)} (${Util.formatFileSize(opts.uploadRes.size)})`)
         .addBreak()
         .addRaw(`This file includes <strong>${refsSize} build record${refsSize > 1 ? 's' : ''}</strong>.`)
       .addRaw(`</p>`)

--- a/src/github.ts
+++ b/src/github.ts
@@ -237,7 +237,7 @@ export class GitHub {
         .addRaw(addLink('Learn more', 'https://docs.docker.com/go/build-summary/'))
       .addRaw('</p>')
       .addRaw(`<p>`)
-        .addRaw(`:arrow_down: ${addLink(`<strong>${opts.uploadRes.filename}</strong>`, artifactRelativeURL)} (${Util.formatFileSize(opts.uploadRes.size)})`)
+        .addRaw(`:arrow_down: ${addLink(`<strong>${Util.stringToUnicodeEntities(opts.uploadRes.filename)}</strong>`, artifactRelativeURL)} (${Util.formatFileSize(opts.uploadRes.size)})`)
         .addBreak()
         .addRaw(`This file includes <strong>${refsSize} build record${refsSize > 1 ? 's' : ''}</strong>.`)
       .addRaw(`</p>`)
@@ -264,7 +264,7 @@ export class GitHub {
         // prettier-ignore
         summaryTableData.push([
           {data: `<code>${ref.substring(0, 6).toUpperCase()}</code>`},
-          {data: `<strong>${summary.name}</strong>`},
+          {data: `<strong>${Util.stringToUnicodeEntities(summary.name)}</strong>`},
           {data: `${summary.status === 'completed' ? ':white_check_mark:' : summary.status === 'canceled' ? ':no_entry_sign:' : ':x:'} ${summary.status}`},
           {data: `${summary.numCachedSteps > 0 ? Math.round((summary.numCachedSteps / summary.numTotalSteps) * 100) : 0}%`},
           {data: summary.duration}

--- a/src/util.ts
+++ b/src/util.ts
@@ -179,4 +179,10 @@ export class Util {
     const bytes = crypto.randomBytes(Math.ceil(length / 2));
     return bytes.toString('hex').slice(0, length);
   }
+
+  public static stringToUnicodeEntities(str: string) {
+    return Array.from(str)
+      .map(char => `&#x${char.charCodeAt(0).toString(16)};`)
+      .join('');
+  }
 }


### PR DESCRIPTION
fixes #367 

Use relative path for artifact link to avoid broken links.

Summary example from integration tests: https://github.com/docker/actions-toolkit/actions/runs/9554693648#summary-26336341867

Artifact link: https://github.com/docker/actions-toolkit/actions/runs/9554693648/artifacts/1610289579

Raw output: https://github.com/docker/actions-toolkit/actions/runs/9554693648/jobs/19145276140/summary_raw

```
<p>:arrow_down: <a href="./9554693648/artifacts/1610289579"><strong>docker~actions-toolkit~WZAZKH.dockerbuild</strong></a> (5.87 KB)<br>
```

___

Added extra commit to convert `.dockerbuild` filename and build name in the summary to unicode entities.

Has been tested on a private repo where a secret value is part of the `.dockerbuild` filename:

![image](https://github.com/docker/actions-toolkit/assets/1951866/d7fbc7fd-20a6-4918-9d45-0949cdc3fdf6)

In this case `test-docker-action` is used as secret value. Here is the raw output of the summary:

```
<h1>Docker Build summary</h1>
<p>For a detailed look at the build, download the following build record archive and import it into Docker Desktop's Builds view. <br>
Build records include details such as timing, dependencies, results, logs, traces, and other information about a build. <a href="https://docs.docker.com/go/build-summary/">Learn more</a></p><p>:arrow_down: <a href="./9562653800/artifacts/1612120571"><strong>&#x64;&#x6f;&#x63;&#x6b;&#x65;&#x72;&#x7e;&#x74;&#x65;&#x73;&#x74;&#x2d;&#x64;&#x6f;&#x63;&#x6b;&#x65;&#x72;&#x2d;&#x61;&#x63;&#x74;&#x69;&#x6f;&#x6e;&#x7e;&#x31;&#x31;&#x53;&#x55;&#x44;&#x31;&#x2e;&#x64;&#x6f;&#x63;&#x6b;&#x65;&#x72;&#x62;&#x75;&#x69;&#x6c;&#x64;</strong></a> (5.44 KB)<br>
This file includes <strong>1 build record</strong>.</p><p>Find this useful? <a href="https://docs.docker.com/feedback/gha-build-summary">Let us know</a></p><h2>Preview</h2>
<table><tr><th>ID</th><th>Name</th><th>Status</th><th>Cached</th><th>Duration</th></tr><tr><td><code>11SUD1</code></td><td><strong>***/summary.Dockerfile</strong></td><td>:white_check_mark: completed</td><td>0%</td><td>1s</td></tr></table>
<h2>Build inputs</h2>
<pre lang="yaml"><code>context: .
file: summary.Dockerfile
labels:
  - org.opencontainers.image.created=2024-06-18T09:36:08.344Z
  - org.opencontainers.image.description=Test "Docker" Actions
  - org.opencontainers.image.licenses=MIT
  - org.opencontainers.image.revision=63f278762688d23ac87122484821e20de9bc625b
  - org.opencontainers.image.source=https://github.com/docker/***
  - org.opencontainers.image.title=***
  - org.opencontainers.image.url=https://github.com/docker/***
  - org.opencontainers.image.version=master
tags:
  - master
</code></pre>
<hr>
```