### PR TITLE
buildx(history): check buildx version before exporting

### DIFF
--- a/src/buildx/history.ts
+++ b/src/buildx/history.ts
@@ -49,6 +49,9 @@ export class History {
     if (!(await Docker.isAvailable())) {
       throw new Error('Docker is required to export a build record');
     }
+    if (!(await this.buildx.versionSatisfies('>=0.13.0'))) {
+      throw new Error('Buildx >= 0.13.0 is required to export a build record');
+    }
 
     let builderName: string = '';
     let nodeName: string = '';


### PR DESCRIPTION
fixes https://github.com/docker/build-push-action/issues/1143
closes https://github.com/docker/build-push-action/pull/1145

Build summary requires Buildx `dial-stdio` command available since Buildx 0.13.0. This adds an extra check to make sure current Buildx version is supported before exporting.