### PR TITLE
ci: only trigger releases json workflow on pr when changed

### DIFF
--- a/.github/workflows/buildx-lab-releases-json.yml
+++ b/.github/workflows/buildx-lab-releases-json.yml
@@ -12,8 +12,8 @@ on:
     branches:
       - 'main'
   pull_request:
-    paths-ignore:
-      - '.github/*-releases.json'
+    paths:
+      - '.github/workflows/buildx-lab-releases-json.yml'
 
 jobs:
   generate:

--- a/.github/workflows/buildx-releases-json.yml
+++ b/.github/workflows/buildx-releases-json.yml
@@ -12,8 +12,8 @@ on:
     branches:
       - 'main'
   pull_request:
-    paths-ignore:
-      - '.github/*-releases.json'
+    paths:
+      - '.github/workflows/buildx-releases-json.yml'
 
 jobs:
   generate:

--- a/.github/workflows/docker-releases-json.yml
+++ b/.github/workflows/docker-releases-json.yml
@@ -12,8 +12,8 @@ on:
     branches:
       - 'main'
   pull_request:
-    paths-ignore:
-      - '.github/*-releases.json'
+    paths:
+      - '.github/workflows/docker-releases-json.yml'
 
 jobs:
   generate:


### PR DESCRIPTION
releases json workflows should be triggered on PR only if the workflow file itself has changed.