### PR TITLE
github(artifact): check upload artifact support for GHES

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -22,6 +22,7 @@ import os from 'os';
 import path from 'path';
 import {CreateArtifactRequest, FinalizeArtifactRequest, StringValue} from '@actions/artifact/lib/generated';
 import {internalArtifactTwirpClient} from '@actions/artifact/lib/internal/shared/artifact-twirp-client';
+import {isGhes} from '@actions/artifact/lib/internal/shared/config';
 import {getBackendIdsFromToken} from '@actions/artifact/lib/internal/shared/util';
 import {getExpiration} from '@actions/artifact/lib/internal/upload/retention';
 import {InvalidResponseError, NetworkError} from '@actions/artifact';
@@ -122,6 +123,10 @@ export class GitHub {
   }
 
   public static async uploadArtifact(opts: UploadArtifactOpts): Promise<UploadArtifactResponse> {
+    if (isGhes()) {
+      throw new Error('@actions/artifact v2.0.0+ is currently not supported on GHES.');
+    }
+
     const artifactName = path.basename(opts.filename);
     const backendIds = getBackendIdsFromToken();
     const artifactClient = internalArtifactTwirpClient();


### PR DESCRIPTION
relates to https://github.com/docker/build-push-action/issues/1154

[`@actions/artifact`](https://www.npmjs.com/package/@actions/artifact) v2+ is not yet supported on GHES. Users trying to upload an artifact will have an error that doesn't give enough context:

```
Failed to get backend IDs: The provided JWT token is invalid and/or missing claims
```

Before trying to downgrade to v1 we should at least return a better error message. This is similar to what `actions/upload-artifact` currently returns: https://github.com/actions/toolkit/blob/361a115e538ac6d8eb06cc47f3fcecce557d04c8/packages/artifact/src/internal/shared/errors.ts#L32