### PR TITLE
buildx: fix resolveRefs for bake

### DIFF
--- a/src/buildx/bake.ts
+++ b/src/buildx/bake.ts
@@ -83,7 +83,7 @@ export class Bake {
         refs.push(metadata[key]['buildx.build.ref']);
       }
     }
-    return refs;
+    return refs.length > 0 ? refs : undefined;
   }
 
   public async getDefinition(cmdOpts: BakeCmdOpts, execOptions?: ExecOptions): Promise<BakeDefinition> {


### PR DESCRIPTION
we should return `undefined` if no ref has been found otherwise following cond https://github.com/docker/bake-action/blob/ff7b24e38552946f89b1398525bf9ec25e6de60e/src/main.ts#L212-L214 is always true and seeking refs in local state would never be done.