### PR TITLE
buildx: use Buffer for base64 encoding of the Dockerfile

### DIFF
--- a/__tests__/.fixtures/lint.Dockerfile
+++ b/__tests__/.fixtures/lint.Dockerfile
@@ -17,6 +17,9 @@
 frOM busybox as base
 cOpy lint.Dockerfile .
 
+# some special chars: distroless/python3-debian12のPythonは3.11
+# https://github.com/docker/build-push-action/issues/1204#issuecomment-2274056016
+
 from scratch
 MAINTAINER moby@example.com
 COPy --from=base \

--- a/src/buildx/buildx.ts
+++ b/src/buildx/buildx.ts
@@ -347,7 +347,7 @@ export class Buildx {
       if (Util.isPathRelativeTo(workspaceDir, ls.DockerfilePath)) {
         dockerfiles.push({
           path: path.relative(workspaceDir, ls.DockerfilePath),
-          content: btoa(fs.readFileSync(ls.DockerfilePath, {encoding: 'utf-8'}))
+          content: Buffer.from(fs.readFileSync(ls.DockerfilePath, {encoding: 'utf-8'}), 'utf-8').toString('base64')
         });
       } else {
         core.debug(`Buildx.convertWarningsToGitHubAnnotations: skipping Dockerfile outside of workspace: ${ls.DockerfilePath}`);


### PR DESCRIPTION
relates to https://github.com/docker/build-push-action/issues/1204