### PR TITLE
context: fix pull request ref

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -45,6 +45,8 @@ export class Context {
     }
     if (github.context.sha && !gitRef.startsWith(`refs/pull/`)) {
       gitRef = github.context.sha;
+    } else if (gitRef.startsWith(`refs/pull/`)) {
+      gitRef = gitRef.replace(/\/merge$/g, '/head');
     }
     return gitRef;
   }


### PR DESCRIPTION
fixes https://github.com/docker/build-push-action/issues/1222

When calling `ls-remote` for Git source in BuildKit like:

```
$ git ls-remote https://github.com/moby/buildkit
185751bdc010f1f8bf1192d6e9b4ec19552d5741        HEAD
05766c5c21a1e528eeb1c3522b2f05493fe9ac47        refs/heads/docker-18.09
396bfe20b590914cd77945ef0d70d976a0ed093c        refs/heads/docker-19.03
185751bdc010f1f8bf1192d6e9b4ec19552d5741        refs/heads/master
d52b2d58424260a86a0387472a59f9a48e522c10        refs/heads/v0.10
435cb77e369c618b9495617278cd276f75bbabe4        refs/heads/v0.11
dbed8c0a42162d1f3e9ec89038d95575e78f8759        refs/heads/v0.12
2e18d709fefdcc2db20853ee241c75b058189d39        refs/heads/v0.13
eb864a84592468ee9b434326cb7efd66f58555af        refs/heads/v0.14
9e14164a1099d3e41b58fc879cbdd6f2b2edb04e        refs/heads/v0.15
8f8fc889432f39e8274072bb0ba7683fd70af91e        refs/heads/v0.16
ed16bc1d795acd30254779f1976bfad46c154583        refs/heads/v0.7
eeb7b65ab7d651770a5ec52a06ea7c96eb97a249        refs/heads/v0.8
83ce906e7a7313d052fd393923346424adb1930e        refs/heads/v0.9
8e7d0904ce97667f47e5bda03a53e285d2e90f9c        refs/pull/10/head
940a31d296a0446d750f36cd6f8c4e6d5161934e        refs/pull/100/head
8e9cc2794e1918bdd429b8bb3fd5677a6c12feed        refs/pull/1001/head
858b4c7076b9fe6bad04c470dd077631408408d8        refs/pull/1002/head
ae6c887689bb5d285249fba2ca398313aed4d42e        refs/pull/1003/head
d71a1c33cd3f3f0f8709e23f7c004ec5d81a6737        refs/pull/1005/head
bffb08a1c4b904c605d0c65e4fe453052bdec9ad        refs/pull/1007/head
0c52d361fd47defdc51f360aa34391a8de9931f6        refs/pull/1008/head
7983ed1e51f1ff80cb0096e709b90d6821b25e57        refs/pull/101/head
ce8597fe7c05247cdfc0b7bc37963e42c4640582        refs/pull/101/merge
dad1297d916fc72d7a3606a36459c6ff7ae9e01b        refs/pull/1010/head
```

It cannot solve a PR that has been merged when using default `github.ref` like `refs/pull/1001/merge` because this is a reference created by GitHub to keep track of what would happen if a pull request was merged and therefore would be removed in such case.

We need to rely on the one ending with `/head`, that points to exactly the same commit as the last commit in the PR branch like `refs/pull/1001/head`.