### PR TITLE
ci: test latest qemu

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,10 +120,6 @@ jobs:
           corepack enable
           yarn --version
       -
-        name: Set up QEMU
-        if: startsWith(matrix.os, 'macos')
-        uses: ./.github/actions/macos-setup-qemu
-      -
         name: Setup Node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
QEMU 9.1.1 available: https://github.com/Homebrew/homebrew-core/pull/195085, let's test it.