### PR TITLE
docker/install: Fix lima failing to download latest Docker archive

### DIFF
--- a/__tests__/docker/install.test.itg.ts
+++ b/__tests__/docker/install.test.itg.ts
@@ -44,6 +44,7 @@ aarch64:https://cloud.debian.org/images/cloud/bookworm/20231013-1532/debian-12-g
     {type: 'image', tag: '27.3.1'} as InstallSourceImage,
     {type: 'image', tag: 'master'} as InstallSourceImage,
     {type: 'archive', version: 'v26.1.4', channel: 'stable'} as InstallSourceArchive,
+    {type: 'archive', version: 'latest', channel: 'stable'} as InstallSourceArchive,
   ])(
     'install docker %s', async (source) => {
       if (process.env.ImageOS && process.env.ImageOS.startsWith('ubuntu')) {

--- a/src/docker/install.ts
+++ b/src/docker/install.ts
@@ -230,7 +230,7 @@ export class Install {
         daemonConfig: limaDaemonConfig,
         dockerSock: `${limaDir}/docker.sock`,
         srcType: src.type,
-        srcArchiveVersion: srcArchive.version?.replace(/^v/, ''),
+        srcArchiveVersion: this._version, // Use the resolved version (e.g. latest -> 27.4.0)
         srcArchiveChannel: srcArchive.channel,
         srcImageTag: (src as InstallSourceImage).tag
       });


### PR DESCRIPTION
Use the actual version number resolved from the Github releases instead of the `latest` string.