### PR TITLE
docker/install: Fix latest image install on lima

### DIFF
--- a/__tests__/docker/install.test.itg.ts
+++ b/__tests__/docker/install.test.itg.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {jest, describe, expect, test, beforeEach, afterEach} from '@jest/globals';
+import {jest, describe, test, beforeEach, afterEach, expect} from '@jest/globals';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -43,6 +43,7 @@ aarch64:https://cloud.debian.org/images/cloud/bookworm/20231013-1532/debian-12-g
   test.each([
     {type: 'image', tag: '27.3.1'} as InstallSourceImage,
     {type: 'image', tag: 'master'} as InstallSourceImage,
+    {type: 'image', tag: 'latest'} as InstallSourceImage,
     {type: 'archive', version: 'v26.1.4', channel: 'stable'} as InstallSourceArchive,
     {type: 'archive', version: 'latest', channel: 'stable'} as InstallSourceArchive,
   ])(
@@ -65,12 +66,17 @@ aarch64:https://cloud.debian.org/images/cloud/bookworm/20231013-1532/debian-12-g
         daemonConfig: `{"debug":true,"features":{"containerd-snapshotter":true}}`
       });
       await expect((async () => {
-        await install.download();
-        await install.install();
-        await Docker.printVersion();
-        await Docker.printInfo();
-      })().finally(async () => {
-        await install.tearDown();
-      })).resolves.not.toThrow();
+        try {
+          await install.download();
+          await install.install();
+          await Docker.printVersion();
+          await Docker.printInfo();
+        } catch (error) {
+          console.error(error);
+          throw error;
+        } finally {
+          await install.tearDown();
+        }
+      })()).resolves.not.toThrow();
     }, 30 * 60 * 1000);
 });

--- a/src/docker/assets.ts
+++ b/src/docker/assets.ts
@@ -237,12 +237,10 @@ provision:
 
       HOME=/tmp undock moby/moby-bin:{{srcImageTag}} /usr/local/bin
 
-      wget https://raw.githubusercontent.com/moby/moby/{{srcImageTag}}/contrib/init/systemd/docker.service \
-        https://raw.githubusercontent.com/moby/moby/v{{srcImageTag}}/contrib/init/systemd/docker.service \
-        -O /etc/systemd/system/docker.service || true
-      wget https://raw.githubusercontent.com/moby/moby/{{srcImageTag}}/contrib/init/systemd/docker.socket \
-        https://raw.githubusercontent.com/moby/moby/v{{srcImageTag}}/contrib/init/systemd/docker.socket \
-        -O /etc/systemd/system/docker.socket || true
+      wget https://raw.githubusercontent.com/moby/moby/{{gitCommit}}/contrib/init/systemd/docker.service \
+        -O /etc/systemd/system/docker.service
+      wget https://raw.githubusercontent.com/moby/moby/{{gitCommit}}/contrib/init/systemd/docker.socket \
+        -O /etc/systemd/system/docker.socket
 
       sed -i 's|^ExecStart=.*|ExecStart=/usr/local/bin/dockerd -H fd://|' /etc/systemd/system/docker.service
       sed -i 's|containerd.service||' /etc/systemd/system/docker.service

--- a/src/types/docker/mediatype.ts
+++ b/src/types/docker/mediatype.ts
@@ -17,3 +17,5 @@
 export const MEDIATYPE_IMAGE_MANIFEST_LIST_V2 = 'application/vnd.docker.distribution.manifest.list.v2+json';
 
 export const MEDIATYPE_IMAGE_MANIFEST_V2 = 'application/vnd.docker.distribution.manifest.v2+json';
+
+export const MEDIATYPE_IMAGE_CONFIG_V1 = 'application/vnd.docker.container.image.v1+json';

--- a/src/types/oci/mediatype.ts
+++ b/src/types/oci/mediatype.ts
@@ -23,3 +23,5 @@ export const MEDIATYPE_IMAGE_INDEX_V1 = 'application/vnd.oci.image.index.v1+json
 export const MEDIATYPE_IMAGE_LAYER_V1 = 'application/vnd.oci.image.layer.v1.tar';
 
 export const MEDIATYPE_EMPTY_JSON_V1 = 'application/vnd.oci.empty.v1+json';
+
+export const MEDIATYPE_IMAGE_CONFIG_V1 = 'application/vnd.oci.image.config.v1+json';


### PR DESCRIPTION
`latest` is not a valid git tag or revision to get the matching systemd unit files.
Look up the exact source git commit from the `org.opencontainers.image.revision` image config label.