### PR TITLE
docker/install: Support rootless

### DIFF
--- a/__tests__/docker/install.test.itg.ts
+++ b/__tests__/docker/install.test.itg.ts
@@ -48,35 +48,77 @@ aarch64:https://cloud.debian.org/images/cloud/bookworm/20231013-1532/debian-12-g
     {type: 'archive', version: 'latest', channel: 'stable'} as InstallSourceArchive,
   ])(
     'install docker %s', async (source) => {
-      if (process.env.ImageOS && process.env.ImageOS.startsWith('ubuntu')) {
-        // Remove containerd first on ubuntu runners to make sure it takes
-        // ones packaged with docker
-        await Exec.exec('sudo', ['apt-get', 'remove', '-y', 'containerd.io'], {
-          env: Object.assign({}, process.env, {
-            DEBIAN_FRONTEND: 'noninteractive'
-          }) as {
-            [key: string]: string;
-          }
-        });
-      }
+      await ensureNoSystemContainerd();
       const install = new Install({
         source: source,
         runDir: tmpDir,
         contextName: 'foo',
         daemonConfig: `{"debug":true,"features":{"containerd-snapshotter":true}}`
       });
-      await expect((async () => {
-        try {
-          await install.download();
-          await install.install();
-          await Docker.printVersion();
-          await Docker.printInfo();
-        } catch (error) {
-          console.error(error);
-          throw error;
-        } finally {
-          await install.tearDown();
-        }
-      })()).resolves.not.toThrow();
+      await expect(tryInstall(install)).resolves.not.toThrow();
     }, 30 * 60 * 1000);
 });
+
+describe('rootless', () => {
+  // prettier-ignore
+  test.each([
+    {type: 'image', tag: 'latest'} as InstallSourceImage,
+    {type: 'archive', version: 'latest', channel: 'stable'} as InstallSourceArchive,
+  ])(
+    'install %s', async (source) => {
+      // Skip on non linux
+      if (os.platform() !== 'linux') {
+        return;
+      }
+
+      await ensureNoSystemContainerd();
+      const install = new Install({
+        source: source,
+        runDir: tmpDir,
+        contextName: 'foo',
+        daemonConfig: `{"debug":true}`,
+        rootless: true
+      });
+      await expect(
+        tryInstall(install, async () => {
+          const out = await Docker.getExecOutput(['info', '-f', '{{json .SecurityOptions}}']);
+          expect(out.exitCode).toBe(0);
+          expect(out.stderr.trim()).toBe('');
+          expect(out.stdout.trim()).toContain('rootless');
+        })
+      ).resolves.not.toThrow();
+    },
+    30 * 60 * 1000
+  );
+});
+
+async function tryInstall(install: Install, extraCheck?: () => Promise<void>): Promise<void> {
+  try {
+    await install.download();
+    await install.install();
+    await Docker.printVersion();
+    await Docker.printInfo();
+    if (extraCheck) {
+      await extraCheck();
+    }
+  } catch (error) {
+    console.error(error);
+    throw error;
+  } finally {
+    await install.tearDown();
+  }
+}
+
+async function ensureNoSystemContainerd() {
+  if (process.env.ImageOS && process.env.ImageOS.startsWith('ubuntu')) {
+    // Remove containerd first on ubuntu runners to make sure it takes
+    // ones packaged with docker
+    await Exec.exec('sudo', ['apt-get', 'remove', '-y', 'containerd.io'], {
+      env: Object.assign({}, process.env, {
+        DEBIAN_FRONTEND: 'noninteractive'
+      }) as {
+        [key: string]: string;
+      }
+    });
+  }
+}


### PR DESCRIPTION
Add support for running a rootless daemon. Currently only Linux host is supported.
    