### PR TITLE
ci: remove deprecated macos-12 runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,6 @@ jobs:
           - ubuntu-latest
           #- macos-14  # no virt: https://github.com/docker/actions-toolkit/issues/317
           - macos-13
-          - macos-12
           - windows-latest
     steps:
       -


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/10721