### PR TITLE
ci: update releases-json to 7f83a5a

### DIFF
--- a/.github/workflows/buildx-lab-releases-json.yml
+++ b/.github/workflows/buildx-lab-releases-json.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   generate:
-    uses: crazy-max/.github/.github/workflows/releases-json.yml@fa6141aedf23596fb8bdcceab9cce8dadaa31bd9
+    uses: crazy-max/.github/.github/workflows/releases-json.yml@7f83a5a887650a38e4d0e05d5262309cfaa31459
     with:
       repository: docker/buildx-desktop
       artifact_name: buildx-lab-releases-json

--- a/.github/workflows/buildx-releases-json.yml
+++ b/.github/workflows/buildx-releases-json.yml
@@ -22,6 +22,7 @@ jobs:
       repository: docker/buildx
       artifact_name: buildx-releases-json
       filename: buildx-releases.json
+      pin_latest: v0.18.0
     secrets: inherit
 
   open-pr:

--- a/.github/workflows/buildx-releases-json.yml
+++ b/.github/workflows/buildx-releases-json.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   generate:
-    uses: crazy-max/.github/.github/workflows/releases-json.yml@fa6141aedf23596fb8bdcceab9cce8dadaa31bd9
+    uses: crazy-max/.github/.github/workflows/releases-json.yml@7f83a5a887650a38e4d0e05d5262309cfaa31459
     with:
       repository: docker/buildx
       artifact_name: buildx-releases-json

--- a/.github/workflows/docker-releases-json.yml
+++ b/.github/workflows/docker-releases-json.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   generate:
-    uses: crazy-max/.github/.github/workflows/releases-json.yml@fa6141aedf23596fb8bdcceab9cce8dadaa31bd9
+    uses: crazy-max/.github/.github/workflows/releases-json.yml@7f83a5a887650a38e4d0e05d5262309cfaa31459
     with:
       repository: moby/moby
       artifact_name: docker-releases-json

--- a/.github/workflows/undock-releases-json.yml
+++ b/.github/workflows/undock-releases-json.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   generate:
-    uses: crazy-max/.github/.github/workflows/releases-json.yml@fa6141aedf23596fb8bdcceab9cce8dadaa31bd9
+    uses: crazy-max/.github/.github/workflows/releases-json.yml@7f83a5a887650a38e4d0e05d5262309cfaa31459
     with:
       repository: crazy-max/undock
       artifact_name: undock-releases-json


### PR DESCRIPTION
follow-up:
* https://github.com/crazy-max/.github/pull/25
* https://github.com/crazy-max/.github/pull/26

Handles `edge` releases so RCs can be tested without updating the tag, for example: https://github.com/docker/actions-toolkit/actions/runs/12049171417/job/33595366893#step:4:12

```json
{
  "latest": {
    "id": 176167883,
    "tag_name": "v27.3.1",
    "html_url": "https://github.com/moby/moby/releases/tag/v27.3.1",
    "assets": []
  },
  "edge": {
    "id": 186229632,
    "tag_name": "v27.4.0-rc.2",
    "html_url": "https://github.com/moby/moby/releases/tag/v27.4.0-rc.2",
    "assets": []
  },
  "v27.4.0-rc.2": {
    "id": 186229632,
    "tag_name": "v27.4.0-rc.2",
    "html_url": "https://github.com/moby/moby/releases/tag/v27.4.0-rc.2",
    "assets": []
  },
  "v27.4.0-rc.1": {
    "id": 185528936,
    "tag_name": "v27.4.0-rc.1",
    "html_url": "https://github.com/moby/moby/releases/tag/v27.4.0-rc.1",
    "assets": []
  },
  ...
}
```

Last commit pin latest of Buildx to v0.18.0 https://github.com/docker/actions-toolkit/actions/runs/12049171429/job/33595366377?pr=510#step:4:6 related to regressions encountered in v0.19.0, see https://github.com/docker/actions-toolkit/pull/508