### PR TITLE
Revert "ci: pin buildx latest to v0.18.0"

### DIFF
--- a/.github/workflows/buildx-releases-json.yml
+++ b/.github/workflows/buildx-releases-json.yml
@@ -22,7 +22,6 @@ jobs:
       repository: docker/buildx
       artifact_name: buildx-releases-json
       filename: buildx-releases.json
-      pin_latest: v0.18.0
     secrets: inherit
 
   open-pr:


### PR DESCRIPTION
This reverts commit 4ea16daf186c653e23246d9669d8f7d175e61107.

Buildx v0.19.1 has been released.