### PR TITLE
buildx(install): rename lab to cloud

### DIFF
--- a/__tests__/buildx/install.test.ts
+++ b/__tests__/buildx/install.test.ts
@@ -134,18 +134,26 @@ describe('getDownloadVersion', () => {
     expect(version.releasesURL).toEqual('https://raw.githubusercontent.com/docker/actions-toolkit/main/.github/buildx-releases.json');
   });
 
-  it('returns lab latest download version', async () => {
-    const version = await Install.getDownloadVersion('lab:latest');
-    expect(version.key).toEqual('lab');
+  it('returns cloud latest download version', async () => {
+    const version = await Install.getDownloadVersion('cloud:latest');
+    expect(version.key).toEqual('cloud');
     expect(version.version).toEqual('latest');
     expect(version.downloadURL).toEqual('https://github.com/docker/buildx-desktop/releases/download/v%s/%s');
     expect(version.releasesURL).toEqual('https://raw.githubusercontent.com/docker/actions-toolkit/main/.github/buildx-lab-releases.json');
   });
 
-  it('returns lab v0.11.2-desktop.2 download version', async () => {
-    const version = await Install.getDownloadVersion('lab:v0.11.2-desktop.2');
-    expect(version.key).toEqual('lab');
+  it('returns cloud v0.11.2-desktop.2 download version', async () => {
+    const version = await Install.getDownloadVersion('cloud:v0.11.2-desktop.2');
+    expect(version.key).toEqual('cloud');
     expect(version.version).toEqual('v0.11.2-desktop.2');
+    expect(version.downloadURL).toEqual('https://github.com/docker/buildx-desktop/releases/download/v%s/%s');
+    expect(version.releasesURL).toEqual('https://raw.githubusercontent.com/docker/actions-toolkit/main/.github/buildx-lab-releases.json');
+  });
+
+  it('returns cloud for lab version', async () => {
+    const version = await Install.getDownloadVersion('lab:latest');
+    expect(version.key).toEqual('cloud');
+    expect(version.version).toEqual('latest');
     expect(version.downloadURL).toEqual('https://github.com/docker/buildx-desktop/releases/download/v%s/%s');
     expect(version.releasesURL).toEqual('https://raw.githubusercontent.com/docker/actions-toolkit/main/.github/buildx-lab-releases.json');
   });
@@ -172,8 +180,8 @@ describe('getRelease', () => {
     expect(release?.html_url).toEqual('https://github.com/docker/buildx/releases/tag/v0.10.1');
   });
 
-  it('returns v0.11.2-desktop.2 lab GitHub release', async () => {
-    const version = await Install.getDownloadVersion('lab:v0.11.2-desktop.2');
+  it('returns v0.11.2-desktop.2 cloud GitHub release', async () => {
+    const version = await Install.getDownloadVersion('cloud:v0.11.2-desktop.2');
     const release = await Install.getRelease(version);
     expect(release).not.toBeNull();
     expect(release?.id).toEqual(118213369);

--- a/src/buildx/install.ts
+++ b/src/buildx/install.ts
@@ -276,6 +276,9 @@ export class Install {
       version = repoKey;
       repoKey = 'official';
     }
+    if (repoKey === 'lab') {
+      repoKey = 'cloud';
+    }
     switch (repoKey) {
       case 'official': {
         return {
@@ -285,7 +288,7 @@ export class Install {
           releasesURL: 'https://raw.githubusercontent.com/docker/actions-toolkit/main/.github/buildx-releases.json'
         };
       }
-      case 'lab': {
+      case 'cloud': {
         return {
           key: repoKey,
           version: version,


### PR DESCRIPTION
Renames `lab` to `cloud` for buildx install version key.

The `lab` key was initially used to provide Buildx releases with features that could not yet fit with public consumption on the upstream repository, such as the `cloud` driver. As we do not expect any other features besides the `cloud` driver support, it is better to make this clear with this change. We keep backward compatibility if someone sets `lab`.