### PR TITLE
context: opt-in pull request head ref

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -39,16 +39,20 @@ export class Context {
   }
 
   public static gitRef(): string {
-    let gitRef = github.context.ref;
-    if (github.context.sha && gitRef && !gitRef.startsWith('refs/')) {
-      gitRef = `refs/heads/${github.context.ref}`;
+    return Context.parseGitRef(github.context.ref, github.context.sha);
+  }
+
+  public static parseGitRef(ref: string, sha: string): string {
+    const setPullRequestHeadRef: boolean = !!(process.env.DOCKER_DEFAULT_GIT_CONTEXT_PR_HEAD_REF && process.env.DOCKER_DEFAULT_GIT_CONTEXT_PR_HEAD_REF === 'true');
+    if (sha && ref && !ref.startsWith('refs/')) {
+      ref = `refs/heads/${ref}`;
     }
-    if (github.context.sha && !gitRef.startsWith(`refs/pull/`)) {
-      gitRef = github.context.sha;
-    } else if (gitRef.startsWith(`refs/pull/`)) {
-      gitRef = gitRef.replace(/\/merge$/g, '/head');
+    if (sha && !ref.startsWith(`refs/pull/`)) {
+      ref = sha;
+    } else if (ref.startsWith(`refs/pull/`) && setPullRequestHeadRef) {
+      ref = ref.replace(/\/merge$/g, '/head');
     }
-    return gitRef;
+    return ref;
   }
 
   public static gitContext(): string {


### PR DESCRIPTION
related to
* https://github.com/docker/actions-toolkit/pull/457
* https://github.com/docker/build-push-action/issues/1222

Using the `/head` ref for pull requests by default is problematic, as it fails to capture upstream changes in the target branch. This discrepancy might lead to different outcomes in CI runs compared to those obtained when running the same workflows against the target branch after merging a PR.

With this change, users will need to set the `DOCKER_DEFAULT_GIT_CONTEXT_PR_HEAD_REF=true` environment variable in their workflows to opt in to tracking the `HEAD` of the development branch, rather than the merge branch that previews the changes after merging into the target branch.

cc @chandanpg