### PR TITLE
context: remove provenanceBuilderID func

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -54,8 +54,4 @@ export class Context {
   public static gitContext(): string {
     return `${GitHub.serverURL}/${github.context.repo.owner}/${github.context.repo.repo}.git#${Context.gitRef()}`;
   }
-
-  public static provenanceBuilderID(): string {
-    return `${GitHub.serverURL}/${github.context.repo.owner}/${github.context.repo.repo}/actions/runs/${github.context.runId}`;
-  }
 }


### PR DESCRIPTION
This function is not used anymore and has been replaced by https://github.com/docker/actions-toolkit/blob/9881e80bfd28a1eab4cbc17ecffbb8fc7318d41b/src/github.ts#L93-L95

Used when solving provenance attributes: https://github.com/docker/actions-toolkit/blob/9881e80bfd28a1eab4cbc17ecffbb8fc7318d41b/src/buildx/build.ts#L162