### PR TITLE
test(github): generate random filename

### DIFF
--- a/__tests__/github.test.itg.ts
+++ b/__tests__/github.test.itg.ts
@@ -25,6 +25,7 @@ import {Build} from '../src/buildx/build';
 import {Exec} from '../src/exec';
 import {GitHub} from '../src/github';
 import {History} from '../src/buildx/history';
+import {Util} from '../src/util';
 
 const fixturesDir = path.join(__dirname, '.fixtures');
 const tmpDir = fs.mkdtempSync(path.join(process.env.TEMP || os.tmpdir(), 'github-itg-'));
@@ -33,8 +34,10 @@ const maybe = !process.env.GITHUB_ACTIONS || (process.env.GITHUB_ACTIONS === 'tr
 
 maybe('uploadArtifact', () => {
   it('uploads an artifact', async () => {
+    const filename = path.join(tmpDir, `github-repo-${Util.generateRandomString()}.json`);
+    fs.copyFileSync(path.join(fixturesDir, `github-repo.json`), filename);
     const res = await GitHub.uploadArtifact({
-      filename: path.join(fixturesDir, 'github-repo.json'),
+      filename: filename,
       mimeType: 'application/json',
       retentionDays: 1
     });


### PR DESCRIPTION
relates to https://github.com/docker/actions-toolkit/actions/runs/12843876100/job/35816318775#step:10:809

```
ERROR: read unix @->/run/docker.sock: use of closed network connection
FAIL __tests__/github.test.itg.ts (50.913 s)
  ● uploadArtifact › uploads an artifact

    Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run

      at ArtifactHttpClient.<anonymous> (node_modules/@actions/artifact/src/internal/shared/artifact-twirp-client.ts:69:13)
          at Generator.throw (<anonymous>)
      at rejected (node_modules/@actions/artifact/lib/internal/shared/artifact-twirp-client.js:6:65)
```