### PR TITLE
compose(install): fix base cache dir

### DIFF
--- a/src/compose/install.ts
+++ b/src/compose/install.ts
@@ -65,7 +65,7 @@ export class Install {
     const installCache = new Cache({
       htcName: version.key != 'official' ? `compose-dl-bin-${version.key}` : 'compose-dl-bin',
       htcVersion: vspec,
-      baseCacheDir: path.join(os.homedir(), '.bin'),
+      baseCacheDir: path.join(os.homedir(), '.bin', 'docker-compose'),
       cacheFile: os.platform() == 'win32' ? 'docker-compose.exe' : 'docker-compose',
       ghaNoCache: ghaNoCache
     });


### PR DESCRIPTION
Atm it would install under `/home/runner/.bin/<version>/<platform>/docker-compose` like `/home/runner/.bin/2.32.4/linux-x64/docker-compose`

We should put the binary under a common folder to avoid confusion.