### PR TITLE
Fix: Remove UTF-8 encoding to prevent mangling of binary secrets

### DIFF
--- a/src/buildx/build.ts
+++ b/src/buildx/build.ts
@@ -139,16 +139,16 @@ export class Build {
   }
 
   public static resolveSecret(kvp: string, file: boolean): [string, string] {
-    const [key, _value] = Build.parseSecretKvp(kvp);
-    let value = _value;
+    const [key, value] = Build.parseSecretKvp(kvp);
+    const secretFile = Context.tmpName({tmpdir: Context.tmpDir()});
     if (file) {
       if (!fs.existsSync(value)) {
         throw new Error(`secret file ${value} not found`);
       }
-      value = fs.readFileSync(value, {encoding: 'utf-8'});
+      fs.copyFileSync(value, secretFile);
+    } else {
+      fs.writeFileSync(secretFile, value);
     }
-    const secretFile = Context.tmpName({tmpdir: Context.tmpDir()});
-    fs.writeFileSync(secretFile, value);
     return [key, secretFile];
   }
 


### PR DESCRIPTION
This PR removes the explicit `encoding: 'utf-8'` from the secret resolution code to ensure binary files are not corrupted. Previously, reading and writing secrets as UTF-8 caused issues when the secret was a binary file. By switching to raw buffers, the code now correctly supports both binary and text-based secrets without any unintended transformations.

- **Removed** `encoding: 'utf-8'` from `fs.readFileSync`.
- **Ensured** raw buffers are used when reading and writing secrets, preventing data corruption.
- **Maintains** existing behavior for text-based secrets, while adding proper support for binary data.