### PR TITLE
undock: fix integration test

### DIFF
--- a/__tests__/undock/undock.test.itg.ts
+++ b/__tests__/undock/undock.test.itg.ts
@@ -17,12 +17,9 @@
 import {describe, expect, it} from '@jest/globals';
 import fs from 'fs';
 import os from 'os';
-import path from 'path';
 
 import {Undock} from '../../src/undock/undock';
 import {Install as UndockInstall} from '../../src/undock/install';
-
-const tmpDir = fs.mkdtempSync(path.join(process.env.TEMP || os.tmpdir(), 'undock-itg-'));
 
 describe('run', () => {
   it('extracts moby/moby-bin:26.1.5', async () => {
@@ -41,9 +38,8 @@ describe('run', () => {
       (async () => {
         // prettier-ignore
         await undock.run({
-          source: 'moby/moby-bin:26.1.5',
-          dist: tmpDir,
-          all: true
+          source: 'docker/buildx-bin:0.23.0',
+          dist: os.tmpdir()
         });
       })()
     ).resolves.not.toThrow();


### PR DESCRIPTION
relates to https://github.com/docker/actions-toolkit/actions/runs/14594348825/job/40936688791?pr=674#step:10:56

```
FAIL __tests__/undock/undock.test.itg.ts (13.326 s)
  ● run › extracts moby/moby-bin:26.1.5

    expect(received).resolves.not.toThrow()

    Received promise rejected instead of resolved
    Rejected to value: [Error: The process 'C:\Users\RUNNER~1\AppData\Local\Temp\docker-actions-toolkit-o3gf3u\runner-temp\docker-actions-toolkit-F6FfTn\undock-bin\undock.exe' failed with exit code 1]

      38 |
      39 |     const undock = new Undock();
    > 40 |     await expect(
         |                 ^
      41 |       (async () => {
      42 |         // prettier-ignore
      43 |         await undock.run({

      at expect (node_modules/expect/build/index.js:113:15)
      at __tests__/undock/undock.test.itg.ts:40:17
      at fulfilled (__tests__/undock/undock.test.itg.ts:20:58)
```