### PR TITLE
test: set proper timeout when downloading binaries

### DIFF
--- a/__tests__/buildx/install.test.ts
+++ b/__tests__/buildx/install.test.ts
@@ -37,19 +37,17 @@ describe('download', () => {
     ['latest', true]
   ])(
   'acquires %p of buildx (standalone: %p)', async (version, standalone) => {
-      const install = new Install({standalone: standalone});
-      const toolPath = await install.download(version);
-      expect(fs.existsSync(toolPath)).toBe(true);
-      let buildxBin: string;
-      if (standalone) {
-        buildxBin = await install.installStandalone(toolPath, tmpDir);
-      } else {
-        buildxBin = await install.installPlugin(toolPath, tmpDir);
-      }
-      expect(fs.existsSync(buildxBin)).toBe(true);
-    },
-    100000
-  );
+    const install = new Install({standalone: standalone});
+    const toolPath = await install.download(version);
+    expect(fs.existsSync(toolPath)).toBe(true);
+    let buildxBin: string;
+    if (standalone) {
+      buildxBin = await install.installStandalone(toolPath, tmpDir);
+    } else {
+      buildxBin = await install.installPlugin(toolPath, tmpDir);
+    }
+    expect(fs.existsSync(buildxBin)).toBe(true);
+  }, 100000);
 
   // prettier-ignore
   test.each([
@@ -57,26 +55,22 @@ describe('download', () => {
     ['v0.9.0'],
     ['v0.10.5'],
   ])(
-    'acquires %p of buildx with cache', async (version) => {
-      const install = new Install({standalone: false});
-      const toolPath = await install.download(version);
-      expect(fs.existsSync(toolPath)).toBe(true);
-    },
-    100000
-  );
+  'acquires %p of buildx with cache', async (version) => {
+    const install = new Install({standalone: false});
+    const toolPath = await install.download(version);
+    expect(fs.existsSync(toolPath)).toBe(true);
+  }, 100000);
 
   // prettier-ignore
   test.each([
     ['v0.11.2'],
     ['v0.12.0'],
   ])(
-    'acquires %p of buildx without cache', async (version) => {
-      const install = new Install({standalone: false});
-      const toolPath = await install.download(version, true);
-      expect(fs.existsSync(toolPath)).toBe(true);
-    },
-    100000
-  );
+  'acquires %p of buildx without cache', async (version) => {
+    const install = new Install({standalone: false});
+    const toolPath = await install.download(version, true);
+    expect(fs.existsSync(toolPath)).toBe(true);
+  }, 100000);
 
   // TODO: add tests for arm
   // prettier-ignore
@@ -90,15 +84,13 @@ describe('download', () => {
     ['linux', 'ppc64'],
     ['linux', 's390x'],
   ])(
-    'acquires buildx for %s/%s', async (os, arch) => {
-      jest.spyOn(osm, 'platform').mockImplementation(() => os as NodeJS.Platform);
-      jest.spyOn(osm, 'arch').mockImplementation(() => arch);
-      const install = new Install();
-      const buildxBin = await install.download('latest');
-      expect(fs.existsSync(buildxBin)).toBe(true);
-    },
-    100000
-  );
+  'acquires buildx for %s/%s', async (os, arch) => {
+    jest.spyOn(osm, 'platform').mockImplementation(() => os as NodeJS.Platform);
+    jest.spyOn(osm, 'arch').mockImplementation(() => arch);
+    const install = new Install();
+    const buildxBin = await install.download('latest');
+    expect(fs.existsSync(buildxBin)).toBe(true);
+  }, 100000);
 });
 
 describe('build', () => {

--- a/__tests__/compose/install.test.ts
+++ b/__tests__/compose/install.test.ts
@@ -36,20 +36,18 @@ describe('download', () => {
     ['v2.32.4', true],
     ['latest', true]
   ])(
-    'acquires %p of compose (standalone: %p)', async (version, standalone) => {
-      const install = new Install({standalone: standalone});
-      const toolPath = await install.download(version);
-      expect(fs.existsSync(toolPath)).toBe(true);
-      let composeBin: string;
-      if (standalone) {
-        composeBin = await install.installStandalone(toolPath, tmpDir);
-      } else {
-        composeBin = await install.installPlugin(toolPath, tmpDir);
-      }
-      expect(fs.existsSync(composeBin)).toBe(true);
-    },
-    100000
-  );
+  'acquires %p of compose (standalone: %p)', async (version, standalone) => {
+    const install = new Install({standalone: standalone});
+    const toolPath = await install.download(version);
+    expect(fs.existsSync(toolPath)).toBe(true);
+    let composeBin: string;
+    if (standalone) {
+      composeBin = await install.installStandalone(toolPath, tmpDir);
+    } else {
+      composeBin = await install.installPlugin(toolPath, tmpDir);
+    }
+    expect(fs.existsSync(composeBin)).toBe(true);
+  }, 100000);
 
   // prettier-ignore
   test.each([
@@ -57,26 +55,22 @@ describe('download', () => {
     ['v2.31.0'],
     ['v2.32.4'],
   ])(
-    'acquires %p of compose with cache', async (version) => {
-      const install = new Install({standalone: false});
-      const toolPath = await install.download(version);
-      expect(fs.existsSync(toolPath)).toBe(true);
-    },
-    100000
-  );
+  'acquires %p of compose with cache', async (version) => {
+    const install = new Install({standalone: false});
+    const toolPath = await install.download(version);
+    expect(fs.existsSync(toolPath)).toBe(true);
+  }, 100000);
 
   // prettier-ignore
   test.each([
     ['v2.27.1'],
     ['v2.28.0'],
   ])(
-    'acquires %p of compose without cache', async (version) => {
-      const install = new Install({standalone: false});
-      const toolPath = await install.download(version, true);
-      expect(fs.existsSync(toolPath)).toBe(true);
-    },
-    100000
-  );
+  'acquires %p of compose without cache', async (version) => {
+    const install = new Install({standalone: false});
+    const toolPath = await install.download(version, true);
+    expect(fs.existsSync(toolPath)).toBe(true);
+  }, 100000);
 
   // TODO: add tests for arm
   // prettier-ignore
@@ -90,15 +84,13 @@ describe('download', () => {
     ['linux', 'ppc64'],
     ['linux', 's390x'],
   ])(
-    'acquires compose for %s/%s', async (os, arch) => {
-      jest.spyOn(osm, 'platform').mockImplementation(() => os as NodeJS.Platform);
-      jest.spyOn(osm, 'arch').mockImplementation(() => arch);
-      const install = new Install();
-      const composeBin = await install.download('latest');
-      expect(fs.existsSync(composeBin)).toBe(true);
-    },
-    100000
-  );
+  'acquires compose for %s/%s', async (os, arch) => {
+    jest.spyOn(osm, 'platform').mockImplementation(() => os as NodeJS.Platform);
+    jest.spyOn(osm, 'arch').mockImplementation(() => arch);
+    const install = new Install();
+    const composeBin = await install.download('latest');
+    expect(fs.existsSync(composeBin)).toBe(true);
+  }, 100000);
 });
 
 describe('getDownloadVersion', () => {

--- a/__tests__/regclient/install.test.ts
+++ b/__tests__/regclient/install.test.ts
@@ -36,14 +36,12 @@ describe('download', () => {
     ['latest']
   ])(
   'acquires %p of regclient', async (version) => {
-      const install = new Install();
-      const toolPath = await install.download(version);
-      expect(fs.existsSync(toolPath)).toBe(true);
-      const regclientBin = await install.install(toolPath, tmpDir);
-      expect(fs.existsSync(regclientBin)).toBe(true);
-    },
-    100000
-  );
+    const install = new Install();
+    const toolPath = await install.download(version);
+    expect(fs.existsSync(toolPath)).toBe(true);
+    const regclientBin = await install.install(toolPath, tmpDir);
+    expect(fs.existsSync(regclientBin)).toBe(true);
+  }, 100000);
 
   // prettier-ignore
   test.each([
@@ -54,7 +52,7 @@ describe('download', () => {
     const install = new Install();
     const toolPath = await install.download(version);
     expect(fs.existsSync(toolPath)).toBe(true);
-  });
+  }, 100000);
 
   // prettier-ignore
   test.each([
@@ -64,7 +62,7 @@ describe('download', () => {
     const install = new Install();
     const toolPath = await install.download(version, true);
     expect(fs.existsSync(toolPath)).toBe(true);
-  });
+  }, 100000);
 
   // prettier-ignore
   test.each([
@@ -77,14 +75,12 @@ describe('download', () => {
     ['linux', 's390x'],
   ])(
   'acquires regclient for %s/%s', async (os, arch) => {
-      jest.spyOn(osm, 'platform').mockImplementation(() => os as NodeJS.Platform);
-      jest.spyOn(osm, 'arch').mockImplementation(() => arch);
-      const install = new Install();
-      const regclientBin = await install.download('latest');
-      expect(fs.existsSync(regclientBin)).toBe(true);
-    },
-    100000
-  );
+    jest.spyOn(osm, 'platform').mockImplementation(() => os as NodeJS.Platform);
+    jest.spyOn(osm, 'arch').mockImplementation(() => arch);
+    const install = new Install();
+    const regclientBin = await install.download('latest');
+    expect(fs.existsSync(regclientBin)).toBe(true);
+  }, 100000);
 });
 
 describe('getDownloadVersion', () => {

--- a/__tests__/undock/install.test.ts
+++ b/__tests__/undock/install.test.ts
@@ -37,14 +37,12 @@ describe('download', () => {
     ['latest']
   ])(
   'acquires %p of undock', async (version) => {
-      const install = new Install();
-      const toolPath = await install.download(version);
-      expect(fs.existsSync(toolPath)).toBe(true);
-      const undockBin = await install.install(toolPath, tmpDir);
-      expect(fs.existsSync(undockBin)).toBe(true);
-    },
-    100000
-  );
+    const install = new Install();
+    const toolPath = await install.download(version);
+    expect(fs.existsSync(toolPath)).toBe(true);
+    const undockBin = await install.install(toolPath, tmpDir);
+    expect(fs.existsSync(undockBin)).toBe(true);
+  }, 100000);
 
   // prettier-ignore
   test.each([
@@ -56,7 +54,7 @@ describe('download', () => {
     const install = new Install();
     const toolPath = await install.download(version);
     expect(fs.existsSync(toolPath)).toBe(true);
-  });
+  }, 100000);
 
   // prettier-ignore
   test.each([
@@ -67,7 +65,7 @@ describe('download', () => {
     const install = new Install();
     const toolPath = await install.download(version, true);
     expect(fs.existsSync(toolPath)).toBe(true);
-  });
+  }, 100000);
 
   // TODO: add tests for arm
   // prettier-ignore
@@ -82,14 +80,12 @@ describe('download', () => {
     ['linux', 's390x'],
   ])(
   'acquires undock for %s/%s', async (os, arch) => {
-      jest.spyOn(osm, 'platform').mockImplementation(() => os as NodeJS.Platform);
-      jest.spyOn(osm, 'arch').mockImplementation(() => arch);
-      const install = new Install();
-      const undockBin = await install.download('latest');
-      expect(fs.existsSync(undockBin)).toBe(true);
-    },
-    100000
-  );
+    jest.spyOn(osm, 'platform').mockImplementation(() => os as NodeJS.Platform);
+    jest.spyOn(osm, 'arch').mockImplementation(() => arch);
+    const install = new Install();
+    const undockBin = await install.download('latest');
+    expect(fs.existsSync(undockBin)).toBe(true);
+  }, 100000);
 });
 
 describe('getDownloadVersion', () => {


### PR DESCRIPTION
relates to https://github.com/docker/actions-toolkit/actions/runs/14441399670/job/40492173583#step:2:3047

```
#25 111.9 FAIL __tests__/undock/install.test.ts (33.919 s)
#25 111.9   ● download › acquires "v0.5.0" of undock without cache
#25 111.9 
#25 111.9     thrown: "Exceeded timeout of 5000 ms for a test.
#25 111.9     Add a timeout value to this test to increase the timeout, if this is a long-running test. See https://jestjs.io/docs/api#testname-fn-timeout."
#25 111.9 
#25 111.9       63 |     ['v0.5.0'],
#25 111.9       64 |     ['v0.6.0'],
#25 111.9     > 65 |   ])(
#25 111.9          |     ^
#25 111.9       66 |   'acquires %p of undock without cache', async (version) => {
#25 111.9       67 |     const install = new Install();
#25 111.9       68 |     const toolPath = await install.download(version, true);
#25 111.9 
#25 111.9       at node_modules/jest-each/build/bind.js:47:15
#25 111.9           at Array.forEach (<anonymous>)
#25 111.9       at __tests__/undock/install.test.ts:65:5
#25 111.9       at Object.<anonymous> (__tests__/undock/install.test.ts:32:9)
```