### PR TITLE
context: use actual git ref instead of commit sha

### DIFF
--- a/__tests__/context.test.ts
+++ b/__tests__/context.test.ts
@@ -58,17 +58,15 @@ describe('parseGitRef', () => {
   });
   // prettier-ignore
   test.each([
-    ['refs/heads/master', '860c1904a1ce19322e91ac35af1ab07466440c37', false, '860c1904a1ce19322e91ac35af1ab07466440c37'],
-    ['master', '860c1904a1ce19322e91ac35af1ab07466440c37', false, '860c1904a1ce19322e91ac35af1ab07466440c37'],
-    ['refs/pull/15/merge', '860c1904a1ce19322e91ac35af1ab07466440c37', false, 'refs/pull/15/merge'],
-    ['refs/heads/master', '', false, 'refs/heads/master'],
-    ['master', '', false, 'master'],
-    ['refs/tags/v1.0.0', '', false, 'refs/tags/v1.0.0'],
-    ['refs/pull/15/merge', '', false, 'refs/pull/15/merge'],
-    ['refs/pull/15/merge', '', true, 'refs/pull/15/head'],
-  ])('given %p and %p, should return %p', async (ref: string, sha: string, prHeadRef: boolean, expected: string) => {
+    ['refs/heads/master', false, 'refs/heads/master'],
+    ['master', false, 'master'],
+    ['refs/pull/15/merge', false, 'refs/pull/15/merge'],
+    ['refs/tags/v1.0.0', false, 'refs/tags/v1.0.0'],
+    ['refs/pull/15/merge', true, 'refs/pull/15/head'],
+    ['', false, '860c1904a1ce19322e91ac35af1ab07466440c37'],
+  ])('given %p and %p, should return %p', async (ref: string, prHeadRef: boolean, expected: string) => {
     process.env.DOCKER_DEFAULT_GIT_CONTEXT_PR_HEAD_REF = prHeadRef ? 'true' : '';
-    expect(Context.parseGitRef(ref, sha)).toEqual(expected);
+    expect(Context.parseGitRef(ref, '860c1904a1ce19322e91ac35af1ab07466440c37')).toEqual(expected);
   });
 });
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -43,13 +43,14 @@ export class Context {
   }
 
   public static parseGitRef(ref: string, sha: string): string {
-    const setPullRequestHeadRef: boolean = !!(process.env.DOCKER_DEFAULT_GIT_CONTEXT_PR_HEAD_REF && process.env.DOCKER_DEFAULT_GIT_CONTEXT_PR_HEAD_REF === 'true');
-    if (sha && ref && !ref.startsWith('refs/')) {
-      ref = `refs/heads/${ref}`;
+    if (!ref) {
+      if (!sha) {
+        throw new Error('Git reference or commit SHA is required');
+      }
+      return sha;
     }
-    if (sha && !ref.startsWith(`refs/pull/`)) {
-      ref = sha;
-    } else if (ref.startsWith(`refs/pull/`) && setPullRequestHeadRef) {
+    const setPullRequestHeadRef: boolean = !!(process.env.DOCKER_DEFAULT_GIT_CONTEXT_PR_HEAD_REF && process.env.DOCKER_DEFAULT_GIT_CONTEXT_PR_HEAD_REF === 'true');
+    if (ref.startsWith(`refs/pull/`) && setPullRequestHeadRef) {
       ref = ref.replace(/\/merge$/g, '/head');
     }
     return ref;


### PR DESCRIPTION
Currently the git reference used with git context for push events (branch or tag) is always set to commit sha. This is problematic as fetching by commit sha does not retrieve tags.

For example in https://github.com/docker/buildx/actions/runs/14474897650/job/40598541434#step:7:495

```
#3 [internal] load git source https://github.com/docker/buildx.git#28c90eadc4c12cc78155ad59ca5f486220241d2a
#3 0.012 Initialized empty Git repository in /var/lib/buildkit/runc-overlayfs/snapshots/snapshots/3/fs/.git/
#3 0.015 commit
#3 1.322 From file:///var/lib/buildkit/runc-overlayfs/snapshots/snapshots/1/fs
#3 1.322  * branch            refs/buildkit/et2ai7t745oioyi79d3m3hs1c -> FETCH_HEAD
#3 2.120 Note: switching to 'FETCH_HEAD'.
#3 2.120 
#3 2.120 You are in 'detached HEAD' state. You can look around, make experimental
#3 2.120 changes and commit them, and you can discard any commits you make in this
#3 2.120 state without impacting any branches by switching back to a branch.
#3 2.120 
#3 2.120 If you want to create a new branch to retain commits you create, you may
#3 2.120 do so (now or later) by using -c with the switch command. Example:
#3 2.120 
#3 2.120   git switch -c <new-branch-name>
#3 2.120 
#3 2.120 Or undo this operation with:
#3 2.120 
#3 2.120   git switch -
#3 2.120 
#3 2.120 Turn off this advice by setting config variable advice.detachedHead to false
#3 2.120 
#3 2.120 HEAD is now at 28c90ea Merge pull request #3116 from crazy-max/v0.23-picks-0.23.0
#3 DONE 2.1s
...
 #32 [linux/amd64 buildx-build 1/1] RUN --mount=type=bind,target=.   --mount=type=cache,target=/root/.cache   --mount=type=cache,target=/go/pkg/mod   --mount=type=bind,from=buildx-version,source=/buildx-version,target=/buildx-version <<EOT (set -e...)
#32 0.340 + CGO_ENABLED=0 go build -mod vendor -trimpath -ldflags '-X github.com/docker/buildx/version.Version=28c90ea -X github.com/docker/buildx/version.Revision=28c90eadc4c12cc78155ad59ca5f486220241d2a -X github.com/docker/buildx/version.Package=github.com/docker/buildx -s -w' -o /usr/bin/docker-buildx ./cmd/buildx
#32 ...
```

This workflow runs on push event with `refs/tags/v0.23.0` git reference but here `version.Version` is set to `28c90ea` because BuildKit fetches by commit sha and no tags are fetched.

It leads to inconsistency with `actions/checkout` action that fetches by git reference with tags.

With this change we are setting the actual git reference and fallback to commit sha if GitHub context does not have a ref (should never happen).

Before:

```
$ docker buildx bake https://github.com/docker/buildx.git#28c90eadc4c12cc78155ad59ca5f486220241d2a
...
#2 [internal] load git source https://github.com/docker/buildx.git#28c90eadc4c12cc78155ad59ca5f486220241d2a
#2 0.040 Initialized empty Git repository in /var/lib/docker/overlay2/hh69bksmo36g5zue054yzl7pu/diff/.git/
#2 0.043 commit
#2 0.460 From file:///var/lib/docker/overlay2/3035vhcu76jdybl0vivmtyedy/diff
#2 0.460  * branch            refs/buildkit/vymteqx5uv90gn7pa5kqjl1ra -> FETCH_HEAD
#2 1.298 Note: switching to 'FETCH_HEAD'.
#2 1.298
#2 1.298 You are in 'detached HEAD' state. You can look around, make experimental
#2 1.298 changes and commit them, and you can discard any commits you make in this
#2 1.298 state without impacting any branches by switching back to a branch.
#2 1.298
#2 1.298 If you want to create a new branch to retain commits you create, you may
#2 1.298 do so (now or later) by using -c with the switch command. Example:
#2 1.298
#2 1.298   git switch -c <new-branch-name>
#2 1.298
#2 1.298 Or undo this operation with:
#2 1.298
#2 1.298   git switch -
#2 1.298
#2 1.298 Turn off this advice by setting config variable advice.detachedHead to false
#2 1.298
#2 1.298 HEAD is now at 28c90ea Merge pull request #3116 from crazy-max/v0.23-picks-0.23.0
#2 DONE 1.3s
...
#13 [buildx-build 1/1] RUN --mount=type=bind,target=.   --mount=type=cache,target=/root/.cache   --mount=type=cache,target=/go/pkg/mod   --mount=type=bind,from=buildx-version,source=/buildx-version,target=/buildx-version <<EOT (set -e...)
#13 0.378 + CGO_ENABLED=0 go build -mod vendor -trimpath -ldflags '-X github.com/docker/buildx/version.Version=28c90ea -X github.com/docker/buildx/version.Revision=28c90eadc4c12cc78155ad59ca5f486220241d2a -X github.com/docker/buildx/version.Package=github.com/docker/buildx -s -w' -o /usr/bin/docker-buildx ./cmd/buildx
```

After:

```
$ docker buildx bake https://github.com/docker/buildx.git#refs/tags/v0.23.0
...
#2 [internal] load git source https://github.com/docker/buildx.git#refs/tags/v0.23.0
#2 0.633 28c90eadc4c12cc78155ad59ca5f486220241d2a       refs/tags/v0.23.0
#2 0.828 Initialized empty Git repository in /var/lib/docker/overlay2/0ppr3of1n71yuli08v2gx2i8n/diff/.git/
#2 0.831 commit
#2 1.271 From file:///var/lib/docker/overlay2/3035vhcu76jdybl0vivmtyedy/diff
#2 1.271  * [new tag]         refs/tags/v0.23.0 -> v0.23.0
#2 1.272  * [new tag]         refs/tags/v0.23.0 -> refs/tags/v0.23.0
#2 2.230 Note: switching to 'FETCH_HEAD'.
#2 2.230
#2 2.230 You are in 'detached HEAD' state. You can look around, make experimental
#2 2.230 changes and commit them, and you can discard any commits you make in this
#2 2.230 state without impacting any branches by switching back to a branch.
#2 2.230
#2 2.230 If you want to create a new branch to retain commits you create, you may
#2 2.230 do so (now or later) by using -c with the switch command. Example:
#2 2.230
#2 2.230   git switch -c <new-branch-name>
#2 2.230
#2 2.230 Or undo this operation with:
#2 2.230
#2 2.230   git switch -
#2 2.230
#2 2.230 Turn off this advice by setting config variable advice.detachedHead to false
#2 2.230
#2 2.230 HEAD is now at 28c90ea Merge pull request #3116 from crazy-max/v0.23-picks-0.23.0
#2 DONE 2.9s
...
#16 [buildx-build 1/1] RUN --mount=type=bind,target=.   --mount=type=cache,target=/root/.cache   --mount=type=cache,target=/go/pkg/mod   --mount=type=bind,from=buildx-version,source=/buildx-version,target=/buildx-version <<EOT (set -e...)
#16 0.354 + CGO_ENABLED=0 go build -mod vendor -trimpath -ldflags '-X github.com/docker/buildx/version.Version=v0.23.0 -X github.com/docker/buildx/version.Revision=28c90eadc4c12cc78155ad59ca5f486220241d2a -X github.com/docker/buildx/version.Package=github.com/docker/buildx -s -w' -o /usr/bin/docker-buildx ./cmd/buildx
```

In the future with CSV support for git context https://github.com/moby/buildkit/pull/5903, we could set both the git reference and commit sha.