### PR TITLE
github: support cloud build URL when writing summary

### DIFF
--- a/src/buildx/history.ts
+++ b/src/buildx/history.ts
@@ -284,10 +284,10 @@ export class History {
     return {
       dockerbuildFilename: dockerbuildPath,
       dockerbuildSize: dockerbuildStats.size,
-      summaries: summaries,
       builderName: builderName,
       nodeName: nodeName,
-      refs: refs
+      refs: refs,
+      summaries: summaries
     };
   }
 

--- a/src/buildx/history.ts
+++ b/src/buildx/history.ts
@@ -130,6 +130,7 @@ export class History {
             numCachedSteps: res.NumCachedSteps,
             numTotalSteps: res.NumTotalSteps,
             numCompletedSteps: res.NumCompletedSteps,
+            defaultPlatform: res.Platform?.[0],
             error: errorLogs
           };
         });

--- a/src/github.ts
+++ b/src/github.ts
@@ -237,6 +237,16 @@ export class GitHub {
 
     const sum = core.summary.addHeading('Docker Build summary', 2);
 
+    if (opts.buildURL) {
+      // prettier-ignore
+      sum.addRaw(`<p>`)
+        .addRaw(`For a detailed look at the build, you can check the results at:`)
+      .addRaw('</p>')
+      .addRaw(`<p>`)
+        .addRaw(`:whale: ${addLink(`<strong>${opts.buildURL}</strong>`, opts.buildURL)}`)
+      .addRaw(`</p>`);
+    }
+
     if (opts.uploadRes) {
       // we just need the last two parts of the URL as they are always relative
       // to the workflow run URL otherwise URL could be broken if GitHub
@@ -246,17 +256,29 @@ export class GitHub {
       // https://github.com/docker/actions-toolkit/issues/367
       const artifactRelativeURL = `./${GitHub.runId}/${opts.uploadRes.url.split('/').slice(-2).join('/')}`;
 
+      if (opts.buildURL) {
+        // prettier-ignore
+        sum.addRaw(`<p>`)
+          .addRaw(`You can also download the following build record archive and import it into Docker Desktop's Builds view. `)
+          .addBreak()
+          .addRaw(`Build records include details such as timing, dependencies, results, logs, traces, and other information about a build. `)
+          .addRaw(addLink('Learn more', 'https://www.docker.com/blog/new-beta-feature-deep-dive-into-github-actions-docker-builds-with-docker-desktop/?utm_source=github&utm_medium=actions'))
+        .addRaw('</p>')
+      } else {
+        // prettier-ignore
+        sum.addRaw(`<p>`)
+          .addRaw(`For a detailed look at the build, download the following build record archive and import it into Docker Desktop's Builds view. `)
+          .addBreak()
+          .addRaw(`Build records include details such as timing, dependencies, results, logs, traces, and other information about a build. `)
+          .addRaw(addLink('Learn more', 'https://www.docker.com/blog/new-beta-feature-deep-dive-into-github-actions-docker-builds-with-docker-desktop/?utm_source=github&utm_medium=actions'))
+        .addRaw('</p>')
+      }
+
       // prettier-ignore
       sum.addRaw(`<p>`)
-        .addRaw(`For a detailed look at the build, download the following build record archive and import it into Docker Desktop's Builds view. `)
-        .addBreak()
-        .addRaw(`Build records include details such as timing, dependencies, results, logs, traces, and other information about a build. `)
-        .addRaw(addLink('Learn more', 'https://www.docker.com/blog/new-beta-feature-deep-dive-into-github-actions-docker-builds-with-docker-desktop/?utm_source=github&utm_medium=actions'))
-      .addRaw('</p>')
-      .addRaw(`<p>`)
         .addRaw(`:arrow_down: ${addLink(`<strong>${Util.stringToUnicodeEntities(opts.uploadRes.filename)}</strong>`, artifactRelativeURL)} (${Util.formatFileSize(opts.uploadRes.size)} - includes <strong>${refsSize} build record${refsSize > 1 ? 's' : ''}</strong>)`)
       .addRaw(`</p>`);
-    } else {
+    } else if (opts.exportRes.summaries) {
       // prettier-ignore
       sum.addRaw(`<p>`)
         .addRaw(`The following table provides a brief summary of your build.`)

--- a/src/types/buildx/history.ts
+++ b/src/types/buildx/history.ts
@@ -131,5 +131,6 @@ export interface Summary {
   numTotalSteps: number;
   numCompletedSteps: number;
   frontendAttrs?: Record<string, string>;
+  defaultPlatform?: string;
   error?: string;
 }

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -59,8 +59,10 @@ export interface UploadArtifactResponse {
 export interface BuildSummaryOpts {
   exportRes: ExportResponse;
   uploadRes?: UploadArtifactResponse;
-  buildURL?: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   inputs?: any;
   bakeDefinition?: BakeDefinition;
+  // builder options
+  driver?: string;
+  endpoint?: string;
 }

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -59,6 +59,7 @@ export interface UploadArtifactResponse {
 export interface BuildSummaryOpts {
   exportRes: ExportResponse;
   uploadRes?: UploadArtifactResponse;
+  buildURL?: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   inputs?: any;
   bakeDefinition?: BakeDefinition;


### PR DESCRIPTION
follow-up https://github.com/docker/build-push-action/pull/1370#discussion_r2084316954
alternative and closes #685

For single build:

![image](https://github.com/user-attachments/assets/8c208a50-8669-4eac-9ba4-833316bb7378)

When there are multiple refs built (with bake-action), the build URL will be set within the summary table for each record.