### PR TITLE
github: fix summary handling for dbc

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -233,15 +233,15 @@ export class GitHub {
       return `<a href="${url}">${text}</a>` + (addEOL ? os.EOL : '');
     };
 
-    const refsSize = Object.keys(opts.exportRes.refs).length;
-    const singleRef = refsSize === 1 ? Object.keys(opts.exportRes.refs)[0] : undefined;
-    const singleSummary = singleRef && opts.exportRes.summaries?.[singleRef];
-    const dbcAccount = opts.driver === 'cloud' && opts.endpoint?.split('/')[0];
+    const refsSize = opts.exportRes.refs.length;
+    const firstRef = refsSize > 0 ? opts.exportRes.refs?.[0] : undefined;
+    const firstSummary = firstRef ? opts.exportRes.summaries?.[firstRef] : undefined;
+    const dbcAccount = opts.driver === 'cloud' && opts.endpoint ? opts.endpoint?.replace(/^cloud:\/\//, '').split('/')[0] : undefined;
 
     const sum = core.summary.addHeading('Docker Build summary', 2);
 
-    if (dbcAccount && singleRef && singleSummary) {
-      const buildURL = GitHub.formatDBCBuildURL(dbcAccount, singleRef, singleSummary.defaultPlatform);
+    if (dbcAccount && refsSize === 1 && firstRef && firstSummary) {
+      const buildURL = GitHub.formatDBCBuildURL(dbcAccount, firstRef, firstSummary.defaultPlatform);
       // prettier-ignore
       sum.addRaw(`<p>`)
         .addRaw(`For a detailed look at the build, you can check the results at:`)


### PR DESCRIPTION
Turns out cloud driver endpoint has a `cloud://` protocol set that we need to take into account. Also fixes an issue where cloud build URL intro was incorrectly displayed for multiple build refs.

### `build-push-action`

![image](https://github.com/user-attachments/assets/01eb2e1b-0365-485a-9003-31cfe391c593)

### `bake-action` (single build)

![image](https://github.com/user-attachments/assets/a093ba1e-903b-4f8e-8cba-87c3ef61c326)

### `bake-action` (multi builds)

![image](https://github.com/user-attachments/assets/13e72691-20de-4b81-92a0-e501af65d3bb)
