### PR TITLE
ci: test node 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         node_version:
+          - 24
           - 20
           - 18
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,7 @@ jobs:
           - ubuntu-latest
           - ubuntu-24.04-arm
         node_version:
+          - 24
           - 20
           - 18
     steps:


### PR DESCRIPTION
Node 24 support is available since runner version 2.327.1 https://github.com/actions/runner/releases/tag/v2.327.1

Didn't default yet to Node 24, I prefer to await at least a month until enough people on self-hosted runners and GHES are compatible.