### PR TITLE
ci: fix docker releases json workflow

### DIFF
--- a/.github/workflows/buildx-lab-releases-json.yml
+++ b/.github/workflows/buildx-lab-releases-json.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   generate:
-    uses: crazy-max/.github/.github/workflows/releases-json.yml@7f83a5a887650a38e4d0e05d5262309cfaa31459
+    uses: crazy-max/.github/.github/workflows/releases-json.yml@9791b02439e3c95de89d128a625169ceee56dc55
     with:
       repository: docker/buildx-desktop
       artifact_name: buildx-lab-releases-json

--- a/.github/workflows/buildx-releases-json.yml
+++ b/.github/workflows/buildx-releases-json.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   generate:
-    uses: crazy-max/.github/.github/workflows/releases-json.yml@7f83a5a887650a38e4d0e05d5262309cfaa31459
+    uses: crazy-max/.github/.github/workflows/releases-json.yml@9791b02439e3c95de89d128a625169ceee56dc55
     with:
       repository: docker/buildx
       artifact_name: buildx-releases-json

--- a/.github/workflows/compose-lab-releases-json.yml
+++ b/.github/workflows/compose-lab-releases-json.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   generate:
-    uses: crazy-max/.github/.github/workflows/releases-json.yml@7f83a5a887650a38e4d0e05d5262309cfaa31459
+    uses: crazy-max/.github/.github/workflows/releases-json.yml@9791b02439e3c95de89d128a625169ceee56dc55
     with:
       repository: docker/compose-desktop
       artifact_name: compose-lab-releases-json

--- a/.github/workflows/compose-releases-json.yml
+++ b/.github/workflows/compose-releases-json.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   generate:
-    uses: crazy-max/.github/.github/workflows/releases-json.yml@7f83a5a887650a38e4d0e05d5262309cfaa31459
+    uses: crazy-max/.github/.github/workflows/releases-json.yml@9791b02439e3c95de89d128a625169ceee56dc55
     with:
       repository: docker/compose
       artifact_name: compose-releases-json

--- a/.github/workflows/docker-releases-json.yml
+++ b/.github/workflows/docker-releases-json.yml
@@ -17,11 +17,12 @@ on:
 
 jobs:
   generate:
-    uses: crazy-max/.github/.github/workflows/releases-json.yml@7f83a5a887650a38e4d0e05d5262309cfaa31459
+    uses: crazy-max/.github/.github/workflows/releases-json.yml@9791b02439e3c95de89d128a625169ceee56dc55
     with:
       repository: moby/moby
       artifact_name: docker-releases-json
       filename: docker-releases.json
+      tag_pattern: '^docker-(.*)$'
     secrets: inherit
 
   open-pr:

--- a/.github/workflows/regclient-releases-json.yml
+++ b/.github/workflows/regclient-releases-json.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   generate:
-    uses: crazy-max/.github/.github/workflows/releases-json.yml@7f83a5a887650a38e4d0e05d5262309cfaa31459
+    uses: crazy-max/.github/.github/workflows/releases-json.yml@9791b02439e3c95de89d128a625169ceee56dc55
     with:
       repository: regclient/regclient
       artifact_name: regclient-releases-json

--- a/.github/workflows/undock-releases-json.yml
+++ b/.github/workflows/undock-releases-json.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   generate:
-    uses: crazy-max/.github/.github/workflows/releases-json.yml@7f83a5a887650a38e4d0e05d5262309cfaa31459
+    uses: crazy-max/.github/.github/workflows/releases-json.yml@9791b02439e3c95de89d128a625169ceee56dc55
     with:
       repository: crazy-max/undock
       artifact_name: undock-releases-json


### PR DESCRIPTION
follow-up https://github.com/crazy-max/.github/pull/57

relates to https://github.com/docker/actions-toolkit/actions/runs/18513943875/job/52760550947#step:3:69

```
Fetching releases for moby/moby
TypeError: Invalid Version: docker-v29.0.0-rc.1
    at new SemVer (/home/runner/work/actions-toolkit/actions-toolkit/node_modules/semver/classes/semver.js:40:13)
    at compare (/home/runner/work/actions-toolkit/actions-toolkit/node_modules/semver/functions/compare.js:5:3)
    at Object.gt (/home/runner/work/actions-toolkit/actions-toolkit/node_modules/semver/functions/gt.js:4:29)
    at eval (eval at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:36187:16), <anonymous>:32:16)
    at async main (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:36285:20)
Error: Unhandled error: TypeError: Invalid Version: docker-v29.0.0-rc.1
```