### PR TITLE
ci(test): update to macos-15-intel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,7 +106,7 @@ jobs:
             });
             await core.group(`Set includes`, async () => {
               let includes = [];
-              for (const os of ['ubuntu-latest', 'ubuntu-24.04-arm', 'macos-13', 'windows-latest']) {
+              for (const os of ['ubuntu-latest', 'ubuntu-24.04-arm', 'macos-15-intel', 'windows-latest']) {
                 for (const test of tests) {
                   if (test === 'docker/install.test.itg.ts') {
                     if (os !== 'windows-latest') {


### PR DESCRIPTION
`macos-13` is deprecated: https://github.com/actions/runner-images/issues/13046

switch to `macos-15-intel` with nested virt support: https://github.com/actions/runner-images/issues/13045