### PR TITLE
sigstore: sign and verify BuildKit attestation manifests

### DIFF
--- a/__tests__/.fixtures/cosign/sign-output1.txt
+++ b/__tests__/.fixtures/cosign/sign-output1.txt
@@ -1,0 +1,300 @@
+25/10/31 12:23:03 --> GET https://public.ecr.aws/v2/
+2025/10/31 12:23:03 GET /v2/ HTTP/1.1
+Host: public.ecr.aws
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Accept-Encoding: gzip
+
+
+2025/10/31 12:23:03 <-- 401 https://public.ecr.aws/v2/ (90.930446ms)
+2025/10/31 12:23:03 HTTP/2.0 401 Unauthorized
+Content-Length: 58
+Content-Type: application/json; charset=utf-8
+Date: Fri, 31 Oct 2025 12:23:03 GMT
+Docker-Distribution-Api-Version: registry/2.0
+Www-Authenticate: ***"https://public.ecr.aws/token/",service="public.ecr.aws",scope="aws"
+
+{"errors":[{"code":"DENIED","message":"Not Authorized"}]}
+
+2025/10/31 12:23:03 --> GET https://public.ecr.aws/token/?scope=repository%3Aq3b5f1u4%2Ftest-docker-action%3Apull&service=public.ecr.aws [body redacted: basic token response contains credentials]
+2025/10/31 12:23:03 GET /token/?scope=repository%3Aq3b5f1u4%2Ftest-docker-action%3Apull&service=public.ecr.aws HTTP/1.1
+Host: public.ecr.aws
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Authorization: <redacted>
+Accept-Encoding: gzip
+
+
+2025/10/31 12:23:03 <-- 200 https://public.ecr.aws/token/?scope=repository%3Aq3b5f1u4%2Ftest-docker-action%3Apull&service=public.ecr.aws (22.311294ms) [body redacted: basic token response contains credentials]
+2025/10/31 12:23:03 HTTP/2.0 200 OK
+Connection: close
+Content-Type: application/json; charset=utf-8
+Date: Fri, 31 Oct 2025 12:23:03 GMT
+Docker-Distribution-Api-Version: registry/2.0
+
+
+2025/10/31 12:23:03 --> GET https://public.ecr.aws/v2/q3b5f1u4/test-docker-action/manifests/sha256:8fe63f8b055569015407e5bd0c78071e87cf921019249b8b7a913091f680a664
+2025/10/31 12:23:03 GET /v2/q3b5f1u4/test-docker-action/manifests/sha256:8fe63f8b055569015407e5bd0c78071e87cf921019249b8b7a913091f680a664 HTTP/1.1
+Host: public.ecr.aws
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Accept: application/vnd.docker.distribution.manifest.v1+json,application/vnd.docker.distribution.manifest.v1+prettyjws,application/vnd.docker.distribution.manifest.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.index.v1+json
+Authorization: <redacted>
+Accept-Encoding: gzip
+
+
+2025/10/31 12:23:03 <-- 200 https://public.ecr.aws/v2/q3b5f1u4/test-docker-action/manifests/sha256:8fe63f8b055569015407e5bd0c78071e87cf921019249b8b7a913091f680a664 (91.079098ms)
+2025/10/31 12:23:03 HTTP/2.0 200 OK
+Content-Length: 1380
+Content-Type: application/vnd.oci.image.manifest.v1+json
+Date: Fri, 31 Oct 2025 12:23:03 GMT
+Docker-Distribution-Api-Version: registry/2.0
+
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "artifactType": "application/vnd.docker.attestation.manifest.v1+json",
+  "config": {
+    "mediaType": "application/vnd.oci.empty.v1+json",
+    "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+    "size": 2,
+    "data": "e30="
+  },
+  "layers": [
+    {
+      "mediaType": "application/vnd.in-toto+json",
+      "digest": "sha256:4035c82011637a22031168bbbf63f591b17b3ab5a8752a17c578def9163b5dbe",
+      "size": 1074,
+      "annotations": {
+        "in-toto.io/predicate-type": "https://spdx.dev/Document"
+      }
+    },
+    {
+      "mediaType": "application/vnd.in-toto+json",
+      "digest": "sha256:f650ede06a7462a0940c41b578760d0755d03cbf4cd1196cab7eb1ea8025e9c9",
+      "size": 81256,
+      "annotations": {
+        "in-toto.io/predicate-type": "https://spdx.dev/Document"
+      }
+    },
+    {
+      "mediaType": "application/vnd.in-toto+json",
+      "digest": "sha256:a2b9b221d0dc010231a6e7e740707e0a7858737305f50d03670674fbccedd91a",
+      "size": 12971,
+      "annotations": {
+        "in-toto.io/predicate-type": "https://slsa.dev/provenance/v1"
+      }
+    }
+  ],
+  "subject": {
+    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+    "digest": "sha256:8d0bfeb83c07fa67a4ce6e5c881608c016a33b3b60c4b4cc787fb3e8deaa7e96",
+    "size": 476
+  }
+}
+Signing artifact...
+2025/10/31 12:23:04 --> GET https://public.ecr.aws/v2/
+2025/10/31 12:23:04 GET /v2/ HTTP/1.1
+Host: public.ecr.aws
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Accept-Encoding: gzip
+
+
+2025/10/31 12:23:04 <-- 401 https://public.ecr.aws/v2/ (92.39115ms)
+2025/10/31 12:23:04 HTTP/2.0 401 Unauthorized
+Content-Length: 58
+Content-Type: application/json; charset=utf-8
+Date: Fri, 31 Oct 2025 12:23:04 GMT
+Docker-Distribution-Api-Version: registry/2.0
+Www-Authenticate: ***"https://public.ecr.aws/token/",service="public.ecr.aws",scope="aws"
+
+{"errors":[{"code":"DENIED","message":"Not Authorized"}]}
+
+2025/10/31 12:23:04 --> GET https://public.ecr.aws/token/?scope=repository%3Aq3b5f1u4%2Ftest-docker-action%3Apull&service=public.ecr.aws [body redacted: basic token response contains credentials]
+2025/10/31 12:23:04 GET /token/?scope=repository%3Aq3b5f1u4%2Ftest-docker-action%3Apull&service=public.ecr.aws HTTP/1.1
+Host: public.ecr.aws
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Authorization: <redacted>
+Accept-Encoding: gzip
+
+
+2025/10/31 12:23:04 <-- 200 https://public.ecr.aws/token/?scope=repository%3Aq3b5f1u4%2Ftest-docker-action%3Apull&service=public.ecr.aws (23.003502ms) [body redacted: basic token response contains credentials]
+2025/10/31 12:23:04 HTTP/2.0 200 OK
+Connection: close
+Content-Type: application/json; charset=utf-8
+Date: Fri, 31 Oct 2025 12:23:04 GMT
+Docker-Distribution-Api-Version: registry/2.0
+
+
+2025/10/31 12:23:04 --> HEAD https://public.ecr.aws/v2/q3b5f1u4/test-docker-action/manifests/sha256:8fe63f8b055569015407e5bd0c78071e87cf921019249b8b7a913091f680a664
+2025/10/31 12:23:04 HEAD /v2/q3b5f1u4/test-docker-action/manifests/sha256:8fe63f8b055569015407e5bd0c78071e87cf921019249b8b7a913091f680a664 HTTP/1.1
+Host: public.ecr.aws
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Accept: application/vnd.docker.distribution.manifest.v1+json,application/vnd.docker.distribution.manifest.v1+prettyjws,application/vnd.docker.distribution.manifest.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.index.v1+json
+Authorization: <redacted>
+
+
+2025/10/31 12:23:04 <-- 200 https://public.ecr.aws/v2/q3b5f1u4/test-docker-action/manifests/sha256:8fe63f8b055569015407e5bd0c78071e87cf921019249b8b7a913091f680a664 (97.669676ms)
+2025/10/31 12:23:04 HTTP/2.0 200 OK
+Content-Length: 1380
+Content-Type: application/vnd.oci.image.manifest.v1+json
+Date: Fri, 31 Oct 2025 12:23:04 GMT
+Docker-Content-Digest: sha256:8fe63f8b055569015407e5bd0c78071e87cf921019249b8b7a913091f680a664
+Docker-Distribution-Api-Version: registry/2.0
+
+
+2025/10/31 12:23:04 --> GET https://public.ecr.aws/v2/
+2025/10/31 12:23:04 GET /v2/ HTTP/1.1
+Host: public.ecr.aws
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Accept-Encoding: gzip
+
+
+2025/10/31 12:23:04 <-- 401 https://public.ecr.aws/v2/ (22.769592ms)
+2025/10/31 12:23:04 HTTP/2.0 401 Unauthorized
+Content-Length: 58
+Content-Type: application/json; charset=utf-8
+Date: Fri, 31 Oct 2025 12:23:04 GMT
+Docker-Distribution-Api-Version: registry/2.0
+Www-Authenticate: ***"https://public.ecr.aws/token/",service="public.ecr.aws",scope="aws"
+
+{"errors":[{"code":"DENIED","message":"Not Authorized"}]}
+
+2025/10/31 12:23:04 --> GET https://public.ecr.aws/token/?scope=repository%3Aq3b5f1u4%2Ftest-docker-action%3Apush%2Cpull&service=public.ecr.aws [body redacted: basic token response contains credentials]
+2025/10/31 12:23:04 GET /token/?scope=repository%3Aq3b5f1u4%2Ftest-docker-action%3Apush%2Cpull&service=public.ecr.aws HTTP/1.1
+Host: public.ecr.aws
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Authorization: <redacted>
+Accept-Encoding: gzip
+
+
+2025/10/31 12:23:04 <-- 200 https://public.ecr.aws/token/?scope=repository%3Aq3b5f1u4%2Ftest-docker-action%3Apush%2Cpull&service=public.ecr.aws (23.492809ms) [body redacted: basic token response contains credentials]
+2025/10/31 12:23:04 HTTP/2.0 200 OK
+Connection: close
+Content-Type: application/json; charset=utf-8
+Date: Fri, 31 Oct 2025 12:23:04 GMT
+Docker-Distribution-Api-Version: registry/2.0
+
+
+2025/10/31 12:23:04 --> HEAD https://public.ecr.aws/v2/q3b5f1u4/test-docker-action/blobs/sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+2025/10/31 12:23:04 HEAD /v2/q3b5f1u4/test-docker-action/blobs/sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a HTTP/1.1
+Host: public.ecr.aws
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Authorization: <redacted>
+
+
+2025/10/31 12:23:04 <-- 200 https://public.ecr.aws/v2/q3b5f1u4/test-docker-action/blobs/sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a (87.79419ms)
+2025/10/31 12:23:04 HTTP/2.0 200 OK
+Content-Length: 2
+Content-Type: application/vnd.oci.empty.v1+json
+Date: Fri, 31 Oct 2025 12:23:04 GMT
+Docker-Content-Digest: sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+Docker-Distribution-Api-Version: registry/2.0
+
+
+2025/10/31 12:23:04 --> HEAD https://public.ecr.aws/v2/q3b5f1u4/test-docker-action/blobs/sha256:2b4c5c9d02679447fac16423a8f30512d32779434b4cd09ec4e37c370fca72f8
+2025/10/31 12:23:04 HEAD /v2/q3b5f1u4/test-docker-action/blobs/sha256:2b4c5c9d02679447fac16423a8f30512d32779434b4cd09ec4e37c370fca72f8 HTTP/1.1
+Host: public.ecr.aws
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Authorization: <redacted>
+
+
+2025/10/31 12:23:04 <-- 404 https://public.ecr.aws/v2/q3b5f1u4/test-docker-action/blobs/sha256:2b4c5c9d02679447fac16423a8f30512d32779434b4cd09ec4e37c370fca72f8 (121.507023ms)
+2025/10/31 12:23:04 HTTP/2.0 404 Not Found
+Connection: close
+Date: Fri, 31 Oct 2025 12:23:04 GMT
+Docker-Distribution-Api-Version: registry/2.0
+
+
+2025/10/31 12:23:04 --> POST https://public.ecr.aws/v2/q3b5f1u4/test-docker-action/blobs/uploads/
+2025/10/31 12:23:04 POST /v2/q3b5f1u4/test-docker-action/blobs/uploads/ HTTP/1.1
+Host: public.ecr.aws
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Content-Length: 0
+Authorization: <redacted>
+Content-Type: application/json
+Accept-Encoding: gzip
+
+
+2025/10/31 12:23:04 <-- 202 https://public.ecr.aws/v2/q3b5f1u4/test-docker-action/blobs/uploads/ (160.219538ms)
+2025/10/31 12:23:04 HTTP/2.0 202 Accepted
+Connection: close
+Date: Fri, 31 Oct 2025 12:23:04 GMT
+Docker-Distribution-Api-Version: registry/2.0
+Location: https://public.ecr.aws/v2/q3b5f1u4/test-docker-action/blobs/uploads/e1f614e2-a6b6-41c6-b753-c4eb2cf5e5e6
+Oci-Chunk-Min-Length: 10485760
+Range: bytes=0-10485760
+
+
+2025/10/31 12:23:04 --> PATCH https://public.ecr.aws/v2/q3b5f1u4/test-docker-action/blobs/uploads/e1f614e2-a6b6-41c6-b753-c4eb2cf5e5e6
+2025/10/31 12:23:04 PATCH /v2/q3b5f1u4/test-docker-action/blobs/uploads/e1f614e2-a6b6-41c6-b753-c4eb2cf5e5e6 HTTP/1.1
+Host: public.ecr.aws
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Content-Length: 10399
+Authorization: <redacted>
+Content-Type: application/octet-stream
+Accept-Encoding: gzip
+
+{"mediaType":"application/vnd.dev.sigstore.bundle.v0.3+json","verificationMaterial":{"certificate":{"rawBytes":"MIIHHjCCBqWgAwIBAgIUWjlTosYeHt52nsSm/sA3nJWlzkswCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUxMDMxMTIyMzAzWhcNMjUxMDMxMTIzMzAzWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE/qmNNDYJCGYdStyJd2nrY42PV9DXNNUqa7r/24tSwqrBtj14L6kloTl7vhdUSlVymqWPVLaAOBuw1EIWO6sGnaOCBcQwggXAMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUVRgm42ZMEV9efm2GOCZ0pxMvM1swHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wgYIGA1UdEQEB/wR4MHaGdGh0dHBzOi8vZ2l0aHViLmNvbS9kb2NrZXIvZ2l0aHViLWJ1aWxkZXItZXhwZXJpbWVudGFsLy5naXRodWIvd29ya2Zsb3dzL2J1aWxkLnltbEByZWZzL2hlYWRzL2J1aWxkLXJldXNhYmxlLXdvcmtmbG93MDkGCisGAQQBg78wAQEEK2h0dHBzOi8vdG9rZW4uYWN0aW9ucy5naXRodWJ1c2VyY29udGVudC5jb20wHwYKKwYBBAGDvzABAgQRd29ya2Zsb3dfZGlzcGF0Y2gwNgYKKwYBBAGDvzABAwQoYTA5ZmM2ZWI4ODM3ZDMwNTQ4YzRkYjI2MDc0YzBiYzY1NTFlOTIxNTAQBgorBgEEAYO/MAEEBAJjaTAoBgorBgEEAYO/MAEFBBpkb2NrZXIvZ2l0aHViLWJ1aWxkZXItdGVzdDAdBgorBgEEAYO/MAEGBA9yZWZzL2hlYWRzL21haW4wOwYKKwYBBAGDvzABCAQtDCtodHRwczovL3Rva2VuLmFjdGlvbnMuZ2l0aHVidXNlcmNvbnRlbnQuY29tMIGEBgorBgEEAYO/MAEJBHYMdGh0dHBzOi8vZ2l0aHViLmNvbS9kb2NrZXIvZ2l0aHViLWJ1aWxkZXItZXhwZXJpbWVudGFsLy5naXRodWIvd29ya2Zsb3dzL2J1aWxkLnltbEByZWZzL2hlYWRzL2J1aWxkLXJldXNhYmxlLXdvcmtmbG93MDgGCisGAQQBg78wAQoEKgwoMGUwZDQ2NWM2ZGNhMzZmNzNlMDc5OGUzMWU2OTE5OTBmOTllNmVjNDAdBgorBgEEAYO/MAELBA8MDWdpdGh1Yi1ob3N0ZWQwPQYKKwYBBAGDvzABDAQvDC1odHRwczovL2dpdGh1Yi5jb20vZG9ja2VyL2dpdGh1Yi1idWlsZGVyLXRlc3QwOAYKKwYBBAGDvzABDQQqDChhMDlmYzZlYjg4MzdkMzA1NDhjNGRiMjYwNzRjMGJjNjU1MWU5MjE1MB8GCisGAQQBg78wAQ4EEQwPcmVmcy9oZWFkcy9tYWluMBoGCisGAQQBg78wAQ8EDAwKMTA0MDU5NDI4NzApBgorBgEEAYO/MAEQBBsMGWh0dHBzOi8vZ2l0aHViLmNvbS9kb2NrZXIwFwYKKwYBBAGDvzABEQQJDAc1NDI5NDcwMGYGCisGAQQBg78wARIEWAxWaHR0cHM6Ly9naXRodWIuY29tL2RvY2tlci9naXRodWItYnVpbGRlci10ZXN0Ly5naXRodWIvd29ya2Zsb3dzL2NpLnltbEByZWZzL2hlYWRzL21haW4wOAYKKwYBBAGDvzABEwQqDChhMDlmYzZlYjg4MzdkMzA1NDhjNGRiMjYwNzRjMGJjNjU1MWU5MjE1MCEGCisGAQQBg78wARQEEwwRd29ya2Zsb3dfZGlzcGF0Y2gwYQYKKwYBBAGDvzABFQRTDFFodHRwczovL2dpdGh1Yi5jb20vZG9ja2VyL2dpdGh1Yi1idWlsZGVyLXRlc3QvYWN0aW9ucy9ydW5zLzE4OTcyMzc1MTYyL2F0dGVtcHRzLzEwGAYKKwYBBAGDvzABFgQKDAhpbnRlcm5hbDCBiwYKKwYBBAHWeQIEAgR9BHsAeQB3AN09MGrGxxEyYxkeHJlnNwKiSl643jyt/4eKcoAvKe6OAAABmjo4qkgAAAQDAEgwRgIhAPIhp9/1qx/0Jk4wGoafJstlNwxRyHazysLG+dqFkA+dAiEAlaNk0hPQgHjie3xXqTMBCjbpkJdpY28LUw5LC9GVdXgwCgYIKoZIzj0EAwMDZwAwZAIwFqN0tURqQn2TCqnfD93JlKkkhTsnIti+L+yCpkDHFaDqb/wRxGCdJwkfmFhg3uVCAjBqta/GJfvZiuiUCBcDjnc0yXEd2T+kz18PqDwckYJDw5E9kfRfAiuzbQPB79/kkTc="},"tlogEntries":[{"logIndex":"658949562","logId":{"keyId":"wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="},"kindVersion":{"kind":"dsse","version":"0.0.1"},"integratedTime":"1761913383","inclusionPromise":{"signedEntryTimestamp":"MEUCIQDnstANwb5LE1i9KDZ5FL7xEa/cJyn4o2QE1EfBFYGZ7wIgIW/DSEIF+9lNABWjC1RCstfvXEHwr5nSkVZq9I/PYVc="},"inclusionProof":{"logIndex":"537045300","rootHash":"K/3sYCfOOurW5jz3vc3Xe68mOzPzseXLvig+onGHTo8=","treeSize":"537045305","hashes":["gX8GjjGP3em1QIJMEm4tlHcBa56DnV/ljK6NTkrCsAg=","tFkGL+OGoAMUyLPuArv/agdojtCfpnB2ve5bAcvK2Hw=","glvFnAf4iaE48R8xz/3v/IOtCIiIvcOQ2W8L73CebMw=","Jxs+mw9u/us8hxQwo5iV9TjmsMYt7Ba/WFF5DozW5PM=","lkjMRgx8iRl8zRObYlqN1iyeKWc7/ocWWszE/LBRgm0=","hYKYgC0bJLi7dMKQqNMUZu5pxWGMxuhtrzqfZqUW0LQ=","DU1i9y7G6fEVyBMopomsF9Uqn9ikw+3OeJ3m2Lmf99w=","hxeWAKhzQdqOBjOQ8W0MCrMAltMhR69VI25jjbjEb8U=","7eU4MO2rD280XoJuu+dx58GT6AcVjTptjjfcbl2zhx8=","wxy+qRAkZr0OZMsIEhPAvUdGhqViqQbv9IthVGOm3lI=","P6OrPNhquaHIdM/iPT2DlOVW2K/cO02h2h5AGOxNDcE=","T4DqWD42hAtN+vX8jKCWqoC4meE4JekI9LxYGCcPy1M="],"checkpoint":{"envelope":"rekor.sigstore.dev - 1193050959916656506\n537045305\nK/3sYCfOOurW5jz3vc3Xe68mOzPzseXLvig+onGHTo8=\n\n— rekor.sigstore.dev wNI9ajBGAiEAu5Q2PWbspoPaE/eaS2yEVCQr8ur2WPpZ3Ay87Fku154CIQC3KelkLz3LQgOExJ1Hq9aEzsLDl00BinFNpZ4C41XBeA==\n"}},"canonicalizedBody":"eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiZHNzZSIsInNwZWMiOnsiZW52ZWxvcGVIYXNoIjp7ImFsZ29yaXRobSI6InNoYTI1NiIsInZhbHVlIjoiNWFmNjI4MGM4OTA0M2NkMWYxNjFiY2VlN2E1NmQ1Mzk1YTQ5MzgxMDQyNGU0NmQ0MzRkNTY2YTZkMGZiMTBkMCJ9LCJwYXlsb2FkSGFzaCI6eyJhbGdvcml0aG0iOiJzaGEyNTYiLCJ2YWx1ZSI6ImEwYzBkYTNhYmIyMzY1MjM4MGU1MTUxYzE1ZDkyNWRhNzdmMTJiZDg0ZGMwMmVhZTIxZjgxMGJhYWI1MzA1YmUifSwic2lnbmF0dXJlcyI6W3sic2lnbmF0dXJlIjoiTUVVQ0lRRDRXRDFoY3REcTk5enBGTkdqRkwvZnBpWk9kUWVvSU9BR1lBbEthdFExR0FJZ0hJV1IxQ0Q4Mko3V2Z5RFhHZHp0SFFFYmdVc3lQWitmdGwxVFBCVXIzaDQ9IiwidmVyaWZpZXIiOiJMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VoSWFrTkRRbkZYWjBGM1NVSkJaMGxWVjJwc1ZHOXpXV1ZJZERVeWJuTlRiUzl6UVROdVNsZHNlbXR6ZDBObldVbExiMXBKZW1vd1JVRjNUWGNLVG5wRlZrMUNUVWRCTVZWRlEyaE5UV015Ykc1ak0xSjJZMjFWZFZwSFZqSk5ValIzU0VGWlJGWlJVVVJGZUZaNllWZGtlbVJIT1hsYVV6RndZbTVTYkFwamJURnNXa2RzYUdSSFZYZElhR05PVFdwVmVFMUVUWGhOVkVsNVRYcEJlbGRvWTA1TmFsVjRUVVJOZUUxVVNYcE5la0Y2VjJwQlFVMUdhM2RGZDFsSUNrdHZXa2w2YWpCRFFWRlpTVXR2V2tsNmFqQkVRVkZqUkZGblFVVXZjVzFPVGtSWlNrTkhXV1JUZEhsS1pESnVjbGswTWxCV09VUllUazVWY1dFM2NpOEtNalIwVTNkeGNrSjBhakUwVERacmJHOVViRGQyYUdSVlUyeFdlVzF4VjFCV1RHRkJUMEoxZHpGRlNWZFBObk5IYm1GUFEwSmpVWGRuWjFoQlRVRTBSd3BCTVZWa1JIZEZRaTkzVVVWQmQwbElaMFJCVkVKblRsWklVMVZGUkVSQlMwSm5aM0pDWjBWR1FsRmpSRUY2UVdSQ1owNVdTRkUwUlVablVWVldVbWR0Q2pReVdrMUZWamxsWm0weVIwOURXakJ3ZUUxMlRURnpkMGgzV1VSV1VqQnFRa0puZDBadlFWVXpPVkJ3ZWpGWmEwVmFZalZ4VG1wd1MwWlhhWGhwTkZrS1drUTRkMmRaU1VkQk1WVmtSVkZGUWk5M1VqUk5TR0ZIWkVkb01HUklRbnBQYVRoMldqSnNNR0ZJVm1sTWJVNTJZbE01YTJJeVRuSmFXRWwyV2pKc01BcGhTRlpwVEZkS01XRlhlR3RhV0VsMFdsaG9kMXBZU25CaVYxWjFaRWRHYzB4NU5XNWhXRkp2WkZkSmRtUXlPWGxoTWxwellqTmtla3d5U2pGaFYzaHJDa3h1YkhSaVJVSjVXbGRhZWt3eWFHeFpWMUo2VERKS01XRlhlR3RNV0Vwc1pGaE9hRmx0ZUd4TVdHUjJZMjEwYldKSE9UTk5SR3RIUTJselIwRlJVVUlLWnpjNGQwRlJSVVZMTW1nd1pFaENlazlwT0haa1J6bHlXbGMwZFZsWFRqQmhWemwxWTNrMWJtRllVbTlrVjBveFl6SldlVmt5T1hWa1IxWjFaRU0xYWdwaU1qQjNTSGRaUzB0M1dVSkNRVWRFZG5wQlFrRm5VVkprTWpsNVlUSmFjMkl6WkdaYVIyeDZZMGRHTUZreVozZE9aMWxMUzNkWlFrSkJSMFIyZWtGQ0NrRjNVVzlaVkVFMVdtMU5NbHBYU1RSUFJFMHpXa1JOZDA1VVVUUlplbEpyV1dwSk1rMUVZekJaZWtKcFdYcFpNVTVVUm14UFZFbDRUbFJCVVVKbmIzSUtRbWRGUlVGWlR5OU5RVVZGUWtGS2FtRlVRVzlDWjI5eVFtZEZSVUZaVHk5TlFVVkdRa0p3YTJJeVRuSmFXRWwyV2pKc01HRklWbWxNVjBveFlWZDRhd3BhV0VsMFpFZFdlbVJFUVdSQ1oyOXlRbWRGUlVGWlR5OU5RVVZIUWtFNWVWcFhXbnBNTW1oc1dWZFNla3d5TVdoaFZ6UjNUM2RaUzB0M1dVSkNRVWRFQ25aNlFVSkRRVkYwUkVOMGIyUklVbmRqZW05MlRETlNkbUV5Vm5WTWJVWnFaRWRzZG1KdVRYVmFNbXd3WVVoV2FXUllUbXhqYlU1MlltNVNiR0p1VVhVS1dUSTVkRTFKUjBWQ1oyOXlRbWRGUlVGWlR5OU5RVVZLUWtoWlRXUkhhREJrU0VKNlQyazRkbG95YkRCaFNGWnBURzFPZG1KVE9XdGlNazV5V2xoSmRncGFNbXd3WVVoV2FVeFhTakZoVjNocldsaEpkRnBZYUhkYVdFcHdZbGRXZFdSSFJuTk1lVFZ1WVZoU2IyUlhTWFprTWpsNVlUSmFjMkl6WkhwTU1rb3hDbUZYZUd0TWJteDBZa1ZDZVZwWFducE1NbWhzV1ZkU2Vrd3lTakZoVjNoclRGaEtiR1JZVG1oWmJYaHNURmhrZG1OdGRHMWlSemt6VFVSblIwTnBjMGNLUVZGUlFtYzNPSGRCVVc5RlMyZDNiMDFIVlhkYVJGRXlUbGROTWxwSFRtaE5lbHB0VG5wT2JFMUVZelZQUjFWNlRWZFZNazlVUlRWUFZFSnRUMVJzYkFwT2JWWnFUa1JCWkVKbmIzSkNaMFZGUVZsUEwwMUJSVXhDUVRoTlJGZGtjR1JIYURGWmFURnZZak5PTUZwWFVYZFFVVmxMUzNkWlFrSkJSMFIyZWtGQ0NrUkJVWFpFUXpGdlpFaFNkMk42YjNaTU1tUndaRWRvTVZscE5XcGlNakIyV2tjNWFtRXlWbmxNTW1Sd1pFZG9NVmxwTVdsa1YyeHpXa2RXZVV4WVVtd0tZek5SZDA5QldVdExkMWxDUWtGSFJIWjZRVUpFVVZGeFJFTm9hRTFFYkcxWmVscHNXV3BuTkUxNlpHdE5la0V4VGtSb2FrNUhVbWxOYWxsM1RucFNhZ3BOUjBwcVRtcFZNVTFYVlRWTmFrVXhUVUk0UjBOcGMwZEJVVkZDWnpjNGQwRlJORVZGVVhkUVkyMVdiV041T1c5YVYwWnJZM2s1ZEZsWGJIVk5RbTlIQ2tOcGMwZEJVVkZDWnpjNGQwRlJPRVZFUVhkTFRWUkJNRTFFVlRWT1JFazBUbnBCY0VKbmIzSkNaMFZGUVZsUEwwMUJSVkZDUW5OTlIxZG9NR1JJUW5vS1QyazRkbG95YkRCaFNGWnBURzFPZG1KVE9XdGlNazV5V2xoSmQwWjNXVXRMZDFsQ1FrRkhSSFo2UVVKRlVWRktSRUZqTVU1RVNUVk9SR04zVFVkWlJ3cERhWE5IUVZGUlFtYzNPSGRCVWtsRlYwRjRWMkZJVWpCalNFMDJUSGs1Ym1GWVVtOWtWMGwxV1RJNWRFd3lVblpaTW5Sc1kyazVibUZZVW05a1YwbDBDbGx1Vm5CaVIxSnNZMmt4TUZwWVRqQk1lVFZ1WVZoU2IyUlhTWFprTWpsNVlUSmFjMkl6WkhwTU1rNXdURzVzZEdKRlFubGFWMXA2VERKb2JGbFhVbm9LVERJeGFHRlhOSGRQUVZsTFMzZFpRa0pCUjBSMmVrRkNSWGRSY1VSRGFHaE5SR3h0V1hwYWJGbHFaelJOZW1SclRYcEJNVTVFYUdwT1IxSnBUV3BaZHdwT2VsSnFUVWRLYWs1cVZURk5WMVUxVFdwRk1VMURSVWREYVhOSFFWRlJRbWMzT0hkQlVsRkZSWGQzVW1ReU9YbGhNbHB6WWpOa1pscEhiSHBqUjBZd0Nsa3laM2RaVVZsTFMzZFpRa0pCUjBSMmVrRkNSbEZTVkVSR1JtOWtTRkozWTNwdmRrd3laSEJrUjJneFdXazFhbUl5TUhaYVJ6bHFZVEpXZVV3eVpIQUtaRWRvTVZscE1XbGtWMnh6V2tkV2VVeFlVbXhqTTFGMldWZE9NR0ZYT1hWamVUbDVaRmMxZWt4NlJUUlBWR041VFhwak1VMVVXWGxNTWtZd1pFZFdkQXBqU0ZKNlRIcEZkMGRCV1V0TGQxbENRa0ZIUkhaNlFVSkdaMUZMUkVGb2NHSnVVbXhqYlRWb1lrUkRRbWwzV1V0TGQxbENRa0ZJVjJWUlNVVkJaMUk1Q2tKSWMwRmxVVUl6UVU0d09VMUhja2Q0ZUVWNVdYaHJaVWhLYkc1T2QwdHBVMncyTkROcWVYUXZOR1ZMWTI5QmRrdGxOazlCUVVGQ2JXcHZOSEZyWjBFS1FVRlJSRUZGWjNkU1owbG9RVkJKYUhBNUx6RnhlQzh3U21zMGQwZHZZV1pLYzNSc1RuZDRVbmxJWVhwNWMweEhLMlJ4Um10QksyUkJhVVZCYkdGT2F3b3dhRkJSWjBocWFXVXplRmh4VkUxQ1EycGljR3RLWkhCWk1qaE1WWGMxVEVNNVIxWmtXR2QzUTJkWlNVdHZXa2w2YWpCRlFYZE5SRnAzUVhkYVFVbDNDa1p4VGpCMFZWSnhVVzR5VkVOeGJtWkVPVE5LYkV0cmEyaFVjMjVKZEdrclRDdDVRM0JyUkVoR1lVUnhZaTkzVW5oSFEyUktkMnRtYlVab1p6TjFWa01LUVdwQ2NYUmhMMGRLWm5aYWFYVnBWVU5DWTBScWJtTXdlVmhGWkRKVUsydDZNVGhRY1VSM1kydFpTa1IzTlVVNWEyWlNaa0ZwZFhwaVVWQkNOemt2YXdwclZHTTlDaTB0TFMwdFJVNUVJRU5GVWxSSlJrbERRVlJGTFMwdExTMEsifV19fQ=="}],"timestampVerificationData":{"rfc3161Timestamps":[{"signedTimestamp":"MIICyTADAgEAMIICwAYJKoZIhvcNAQcCoIICsTCCAq0CAQMxDTALBglghkgBZQMEAgEwgbcGCyqGSIb3DQEJEAEEoIGnBIGkMIGhAgEBBgkrBgEEAYO/MAIwMTANBglghkgBZQMEAgEFAAQgmyxG8uBDx23ddRbk6PYLazqQUXiBBPmCgCx9ErX7w/ACFEkK7G00ygmDLw/gFO4nF3Ry0jWMGA8yMDI1MTAzMTEyMjMwM1owAwIBAaAypDAwLjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MRUwEwYDVQQDEwxzaWdzdG9yZS10c2GgADGCAdswggHXAgEBMFEwOTEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MSAwHgYDVQQDExdzaWdzdG9yZS10c2Etc2VsZnNpZ25lZAIUOhNULwyQYe68wUMvy4qOiyojiwwwCwYJYIZIAWUDBAIBoIH8MBoGCSqGSIb3DQEJAzENBgsqhkiG9w0BCRABBDAcBgkqhkiG9w0BCQUxDxcNMjUxMDMxMTIyMzAzWjAvBgkqhkiG9w0BCQQxIgQggASUwwEFRvY7eEtrHk+gNvV1AZh37OhIYEeR4aSllMIwgY4GCyqGSIb3DQEJEAIvMX8wfTB7MHkEIIX5J7wHq2LKw7RDVsEO/IGyxog/2nq55thw2dE6zQW3MFUwPaQ7MDkxFTATBgNVBAoTDHNpZ3N0b3JlLmRldjEgMB4GA1UEAxMXc2lnc3RvcmUtdHNhLXNlbGZzaWduZWQCFDoTVC8MkGHuvMFDL8uKjosqI4sMMAoGCCqGSM49BAMCBGcwZQIwSlk2h1jQhL/D/FeMJmf6pndc1iRf4qFMXNFcWcT8QJldpfmKwX5Nk89rvaamBmdXAjEAuLGhWWfd5iu+2YZhFMWNorWdVQRdq/GJfisshCakLSIxkTSYxlvHyVQy54yXqb/q"}]}},"dsseEnvelope":{"payload":"eyJfdHlwZSI6Imh0dHBzOi8vaW4tdG90by5pby9TdGF0ZW1lbnQvdjEiLCJzdWJqZWN0IjpbeyJkaWdlc3QiOnsic2hhMjU2IjoiOGZlNjNmOGIwNTU1NjkwMTU0MDdlNWJkMGM3ODA3MWU4N2NmOTIxMDE5MjQ5YjhiN2E5MTMwOTFmNjgwYTY2NCJ9fV0sInByZWRpY2F0ZVR5cGUiOiJodHRwczovL3NpZ3N0b3JlLmRldi9jb3NpZ24vc2lnbi92MSJ9","payloadType":"application/vnd.in-toto+json","signatures":[{"sig":"MEUCIQD4WD1hctDq99zpFNGjFL/fpiZOdQeoIOAGYAlKatQ1GAIgHIWR1CD82J7WfyDXGdztHQEbgUsyPZ+ftl1TPBUr3h4="}]}}
+2025/10/31 12:23:04 <-- 201 https://public.ecr.aws/v2/q3b5f1u4/test-docker-action/blobs/uploads/e1f614e2-a6b6-41c6-b753-c4eb2cf5e5e6 (132.007246ms)
+2025/10/31 12:23:04 HTTP/2.0 201 Created
+Content-Length: 0
+Date: Fri, 31 Oct 2025 12:23:04 GMT
+Docker-Distribution-Api-Version: registry/2.0
+Docker-Upload-Uuid: e1f614e2-a6b6-41c6-b753-c4eb2cf5e5e6
+Location: https://public.ecr.aws/v2/q3b5f1u4/test-docker-action/blobs/uploads/e1f614e2-a6b6-41c6-b753-c4eb2cf5e5e6
+Range: 0-10398
+
+
+2025/10/31 12:23:04 --> PUT https://public.ecr.aws/v2/q3b5f1u4/test-docker-action/blobs/uploads/e1f614e2-a6b6-41c6-b753-c4eb2cf5e5e6?digest=sha256%3A2b4c5c9d02679447fac16423a8f30512d32779434b4cd09ec4e37c370fca72f8
+2025/10/31 12:23:04 PUT /v2/q3b5f1u4/test-docker-action/blobs/uploads/e1f614e2-a6b6-41c6-b753-c4eb2cf5e5e6?digest=sha256%3A2b4c5c9d02679447fac16423a8f30512d32779434b4cd09ec4e37c370fca72f8 HTTP/1.1
+Host: public.ecr.aws
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Content-Length: 0
+Authorization: <redacted>
+Content-Type: application/octet-stream
+Accept-Encoding: gzip
+
+
+2025/10/31 12:23:05 <-- 201 https://public.ecr.aws/v2/q3b5f1u4/test-docker-action/blobs/uploads/e1f614e2-a6b6-41c6-b753-c4eb2cf5e5e6?digest=sha256%3A2b4c5c9d02679447fac16423a8f30512d32779434b4cd09ec4e37c370fca72f8 (276.8397ms)
+2025/10/31 12:23:05 HTTP/2.0 201 Created
+Content-Length: 0
+Date: Fri, 31 Oct 2025 12:23:05 GMT
+Docker-Content-Digest: sha256:2b4c5c9d02679447fac16423a8f30512d32779434b4cd09ec4e37c370fca72f8
+Docker-Distribution-Api-Version: registry/2.0
+Location: https://public.ecr.aws/v2/q3b5f1u4/test-docker-action/blobs/sha256:2b4c5c9d02679447fac16423a8f30512d32779434b4cd09ec4e37c370fca72f8
+
+
+2025/10/31 12:23:05 --> PUT https://public.ecr.aws/v2/q3b5f1u4/test-docker-action/manifests/sha256:b79760ca789467ba1bf1cf6ff89d71353e23819474e8ffb44a1116ce95a102fa
+2025/10/31 12:23:05 PUT /v2/q3b5f1u4/test-docker-action/manifests/sha256:b79760ca789467ba1bf1cf6ff89d71353e23819474e8ffb44a1116ce95a102fa HTTP/1.1
+Host: public.ecr.aws
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Content-Length: 880
+Authorization: <redacted>
+Content-Type: application/vnd.oci.image.manifest.v1+json
+Accept-Encoding: gzip
+
+{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","config":{"mediaType":"application/vnd.oci.empty.v1+json","size":2,"digest":"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a","artifactType":"application/vnd.dev.sigstore.bundle.v0.3+json"},"layers":[{"mediaType":"application/vnd.dev.sigstore.bundle.v0.3+json","size":10399,"digest":"sha256:2b4c5c9d02679447fac16423a8f30512d32779434b4cd09ec4e37c370fca72f8"}],"annotations":{"dev.sigstore.bundle.content":"dsse-envelope","dev.sigstore.bundle.predicateType":"https://sigstore.dev/cosign/sign/v1","org.opencontainers.image.created":"2025-10-31T12:23:04Z"},"subject":{"mediaType":"application/vnd.oci.image.manifest.v1+json","size":1380,"digest":"sha256:8fe63f8b055569015407e5bd0c78071e87cf921019249b8b7a913091f680a664"},"artifactType":"application/vnd.dev.sigstore.bundle.v0.3+json"}
+2025/10/31 12:23:05 <-- 201 https://public.ecr.aws/v2/q3b5f1u4/test-docker-action/manifests/sha256:b79760ca789467ba1bf1cf6ff89d71353e23819474e8ffb44a1116ce95a102fa (311.620833ms)
+2025/10/31 12:23:05 HTTP/2.0 201 Created
+Content-Length: 0
+Date: Fri, 31 Oct 2025 12:23:05 GMT
+Docker-Content-Digest: sha256:b79760ca789467ba1bf1cf6ff89d71353e23819474e8ffb44a1116ce95a102fa
+Docker-Distribution-Api-Version: registry/2.0
+Oci-Subject: sha256:8fe63f8b055569015407e5bd0c78071e87cf921019249b8b7a913091f680a664
+
+
+2025/10/31 12:23:05 --> GET https://public.ecr.aws/v2/q3b5f1u4/test-docker-action/referrers/sha256:8fe63f8b055569015407e5bd0c78071e87cf921019249b8b7a913091f680a664
+2025/10/31 12:23:05 GET /v2/q3b5f1u4/test-docker-action/referrers/sha256:8fe63f8b055569015407e5bd0c78071e87cf921019249b8b7a913091f680a664 HTTP/1.1
+Host: public.ecr.aws
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Accept: application/vnd.oci.image.index.v1+json
+Authorization: <redacted>
+Accept-Encoding: gzip
+
+
+2025/10/31 12:23:05 <-- 200 https://public.ecr.aws/v2/q3b5f1u4/test-docker-action/referrers/sha256:8fe63f8b055569015407e5bd0c78071e87cf921019249b8b7a913091f680a664 (151.162755ms)
+2025/10/31 12:23:05 HTTP/2.0 200 OK
+Content-Length: 497
+Content-Type: application/vnd.oci.image.index.v1+json
+Date: Fri, 31 Oct 2025 12:23:05 GMT
+Docker-Distribution-Api-Version: registry/2.0
+
+{"manifests":[{"digest":"sha256:b79760ca789467ba1bf1cf6ff89d71353e23819474e8ffb44a1116ce95a102fa","mediaType":"application/vnd.oci.image.manifest.v1+json","artifactType":"application/vnd.dev.sigstore.bundle.v0.3+json","size":880,"annotations":{"dev.sigstore.bundle.content":"dsse-envelope","dev.sigstore.bundle.predicateType":"https://sigstore.dev/cosign/sign/v1","org.opencontainers.image.created":"2025-10-31T12:23:04Z"}}],"mediaType":"application/vnd.oci.image.index.v1+json","schemaVersion":2}

--- a/__tests__/.fixtures/cosign/sign-output2.txt
+++ b/__tests__/.fixtures/cosign/sign-output2.txt
@@ -1,0 +1,408 @@
+25/10/31 12:23:12 --> GET https://ghcr.io/v2/
+2025/10/31 12:23:12 GET /v2/ HTTP/1.1
+Host: ghcr.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Accept-Encoding: gzip
+
+
+2025/10/31 12:23:13 <-- 401 https://ghcr.io/v2/ (89.150488ms)
+2025/10/31 12:23:13 HTTP/2.0 401 Unauthorized
+Content-Length: 73
+Content-Type: application/json
+Date: Fri, 31 Oct 2025 12:23:13 GMT
+Docker-Distribution-Api-Version: registry/2.0
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+Www-Authenticate: ***"https://ghcr.io/token",service="ghcr.io",scope="repository:user/image:pull"
+X-Github-Request-Id: 6801:2BD711:1CF2F3:21999C:6904AA31
+
+{"errors":[{"code":"UNAUTHORIZED","message":"authentication required"}]}
+
+2025/10/31 12:23:13 --> GET https://ghcr.io/token?scope=repository%3Adocker%2Fgithub-builder-test%3Apull&service=ghcr.io [body redacted: basic token response contains credentials]
+2025/10/31 12:23:13 GET /token?scope=repository%3Adocker%2Fgithub-builder-test%3Apull&service=ghcr.io HTTP/1.1
+Host: ghcr.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Authorization: <redacted>
+Accept-Encoding: gzip
+
+
+2025/10/31 12:23:13 <-- 200 https://ghcr.io/token?scope=repository%3Adocker%2Fgithub-builder-test%3Apull&service=ghcr.io (77.913846ms) [body redacted: basic token response contains credentials]
+2025/10/31 12:23:13 HTTP/2.0 200 OK
+Content-Length: 69
+Content-Type: application/json
+Date: Fri, 31 Oct 2025 12:23:13 GMT
+Docker-Distribution-Api-Version: registry/2.0
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+X-Github-Request-Id: 6801:2BD711:1CF2FF:2199A6:6904AA31
+
+
+2025/10/31 12:23:13 --> GET https://ghcr.io/v2/docker/github-builder-test/manifests/sha256:c6fc458cc8718628e8fb8b699d2991056590e0fed4ea0d6f86583705202bdce4
+2025/10/31 12:23:13 GET /v2/docker/github-builder-test/manifests/sha256:c6fc458cc8718628e8fb8b699d2991056590e0fed4ea0d6f86583705202bdce4 HTTP/1.1
+Host: ghcr.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Accept: application/vnd.docker.distribution.manifest.v1+json,application/vnd.docker.distribution.manifest.v1+prettyjws,application/vnd.docker.distribution.manifest.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.index.v1+json
+Authorization: <redacted>
+Accept-Encoding: gzip
+
+
+2025/10/31 12:23:13 <-- 200 https://ghcr.io/v2/docker/github-builder-test/manifests/sha256:c6fc458cc8718628e8fb8b699d2991056590e0fed4ea0d6f86583705202bdce4 (123.693613ms)
+2025/10/31 12:23:13 HTTP/2.0 200 OK
+Content-Length: 1380
+Content-Type: application/vnd.oci.image.manifest.v1+json
+Date: Fri, 31 Oct 2025 12:23:13 GMT
+Docker-Content-Digest: sha256:c6fc458cc8718628e8fb8b699d2991056590e0fed4ea0d6f86583705202bdce4
+Docker-Distribution-Api-Version: registry/2.0
+Etag: "sha256:c6fc458cc8718628e8fb8b699d2991056590e0fed4ea0d6f86583705202bdce4"
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+X-Github-Request-Id: 6801:2BD711:1CF313:2199BD:6904AA31
+
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "artifactType": "application/vnd.docker.attestation.manifest.v1+json",
+  "config": {
+    "mediaType": "application/vnd.oci.empty.v1+json",
+    "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+    "size": 2,
+    "data": "e30="
+  },
+  "layers": [
+    {
+      "mediaType": "application/vnd.in-toto+json",
+      "digest": "sha256:7a5799d5199ade2a153ad2a7dcb18ea47801eacdb60baab8888bdddf1b7625db",
+      "size": 1066,
+      "annotations": {
+        "in-toto.io/predicate-type": "https://spdx.dev/Document"
+      }
+    },
+    {
+      "mediaType": "application/vnd.in-toto+json",
+      "digest": "sha256:82c4b93ca70a89e9905a66223e9b20b4fed6b8ae4b49a9fa15a576556637b47f",
+      "size": 81248,
+      "annotations": {
+        "in-toto.io/predicate-type": "https://spdx.dev/Document"
+      }
+    },
+    {
+      "mediaType": "application/vnd.in-toto+json",
+      "digest": "sha256:ef2bf2ba303ba8a61a16ff013a69db540e27693a9c4c2e00dddeb3a171ba94a5",
+      "size": 12963,
+      "annotations": {
+        "in-toto.io/predicate-type": "https://slsa.dev/provenance/v1"
+      }
+    }
+  ],
+  "subject": {
+    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+    "digest": "sha256:d496a83e4181e4e552e502411b2e1714059d52e2d8249f9e629f7728de894b5c",
+    "size": 476
+  }
+}
+Signing artifact...
+2025/10/31 12:23:14 --> GET https://ghcr.io/v2/
+2025/10/31 12:23:14 GET /v2/ HTTP/1.1
+Host: ghcr.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Accept-Encoding: gzip
+
+
+2025/10/31 12:23:14 <-- 401 https://ghcr.io/v2/ (95.609743ms)
+2025/10/31 12:23:14 HTTP/2.0 401 Unauthorized
+Content-Length: 73
+Content-Type: application/json
+Date: Fri, 31 Oct 2025 12:23:14 GMT
+Docker-Distribution-Api-Version: registry/2.0
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+Www-Authenticate: ***"https://ghcr.io/token",service="ghcr.io",scope="repository:user/image:pull"
+X-Github-Request-Id: 6802:6EC77:1D0CD6:21D994:6904AA32
+
+{"errors":[{"code":"UNAUTHORIZED","message":"authentication required"}]}
+
+2025/10/31 12:23:14 --> GET https://ghcr.io/token?scope=repository%3Adocker%2Fgithub-builder-test%3Apull&service=ghcr.io [body redacted: basic token response contains credentials]
+2025/10/31 12:23:14 GET /token?scope=repository%3Adocker%2Fgithub-builder-test%3Apull&service=ghcr.io HTTP/1.1
+Host: ghcr.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Authorization: <redacted>
+Accept-Encoding: gzip
+
+
+2025/10/31 12:23:14 <-- 200 https://ghcr.io/token?scope=repository%3Adocker%2Fgithub-builder-test%3Apull&service=ghcr.io (84.855255ms) [body redacted: basic token response contains credentials]
+2025/10/31 12:23:14 HTTP/2.0 200 OK
+Content-Length: 69
+Content-Type: application/json
+Date: Fri, 31 Oct 2025 12:23:14 GMT
+Docker-Distribution-Api-Version: registry/2.0
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+X-Github-Request-Id: 6802:6EC77:1D0CDE:21D9A0:6904AA32
+
+
+2025/10/31 12:23:14 --> HEAD https://ghcr.io/v2/docker/github-builder-test/manifests/sha256:c6fc458cc8718628e8fb8b699d2991056590e0fed4ea0d6f86583705202bdce4
+2025/10/31 12:23:14 HEAD /v2/docker/github-builder-test/manifests/sha256:c6fc458cc8718628e8fb8b699d2991056590e0fed4ea0d6f86583705202bdce4 HTTP/1.1
+Host: ghcr.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Accept: application/vnd.docker.distribution.manifest.v1+json,application/vnd.docker.distribution.manifest.v1+prettyjws,application/vnd.docker.distribution.manifest.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.index.v1+json
+Authorization: <redacted>
+
+
+2025/10/31 12:23:14 <-- 200 https://ghcr.io/v2/docker/github-builder-test/manifests/sha256:c6fc458cc8718628e8fb8b699d2991056590e0fed4ea0d6f86583705202bdce4 (71.474101ms)
+2025/10/31 12:23:14 HTTP/2.0 200 OK
+Content-Length: 1380
+Content-Type: application/vnd.oci.image.manifest.v1+json
+Date: Fri, 31 Oct 2025 12:23:14 GMT
+Docker-Content-Digest: sha256:c6fc458cc8718628e8fb8b699d2991056590e0fed4ea0d6f86583705202bdce4
+Docker-Distribution-Api-Version: registry/2.0
+Etag: "sha256:c6fc458cc8718628e8fb8b699d2991056590e0fed4ea0d6f86583705202bdce4"
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+X-Github-Request-Id: 6802:6EC77:1D0CF3:21D9BA:6904AA32
+
+
+2025/10/31 12:23:14 --> GET https://ghcr.io/v2/
+2025/10/31 12:23:14 GET /v2/ HTTP/1.1
+Host: ghcr.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Accept-Encoding: gzip
+
+
+2025/10/31 12:23:14 <-- 401 https://ghcr.io/v2/ (30.699866ms)
+2025/10/31 12:23:14 HTTP/2.0 401 Unauthorized
+Content-Length: 73
+Content-Type: application/json
+Date: Fri, 31 Oct 2025 12:23:14 GMT
+Docker-Distribution-Api-Version: registry/2.0
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+Www-Authenticate: ***"https://ghcr.io/token",service="ghcr.io",scope="repository:user/image:pull"
+X-Github-Request-Id: 6802:6EC77:1D0D02:21D9C9:6904AA32
+
+{"errors":[{"code":"UNAUTHORIZED","message":"authentication required"}]}
+
+2025/10/31 12:23:14 --> GET https://ghcr.io/token?scope=repository%3Adocker%2Fgithub-builder-test%3Apush%2Cpull&service=ghcr.io [body redacted: basic token response contains credentials]
+2025/10/31 12:23:14 GET /token?scope=repository%3Adocker%2Fgithub-builder-test%3Apush%2Cpull&service=ghcr.io HTTP/1.1
+Host: ghcr.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Authorization: <redacted>
+Accept-Encoding: gzip
+
+
+2025/10/31 12:23:14 <-- 200 https://ghcr.io/token?scope=repository%3Adocker%2Fgithub-builder-test%3Apush%2Cpull&service=ghcr.io (75.969624ms) [body redacted: basic token response contains credentials]
+2025/10/31 12:23:14 HTTP/2.0 200 OK
+Content-Length: 69
+Content-Type: application/json
+Date: Fri, 31 Oct 2025 12:23:14 GMT
+Docker-Distribution-Api-Version: registry/2.0
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+X-Github-Request-Id: 6802:6EC77:1D0D09:21D9D5:6904AA32
+
+
+2025/10/31 12:23:14 --> HEAD https://ghcr.io/v2/docker/github-builder-test/blobs/sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+2025/10/31 12:23:14 HEAD /v2/docker/github-builder-test/blobs/sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a HTTP/1.1
+Host: ghcr.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Authorization: <redacted>
+
+
+2025/10/31 12:23:14 <-- 200 https://ghcr.io/v2/docker/github-builder-test/blobs/sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a (98.215603ms)
+2025/10/31 12:23:14 HTTP/2.0 200 OK
+Content-Length: 2
+Content-Type: application/vnd.oci.empty.v1+json
+Date: Fri, 31 Oct 2025 12:23:14 GMT
+Docker-Content-Digest: sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+Docker-Distribution-Api-Version: registry/2.0
+Etag: "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+X-Github-Request-Id: 6802:6EC77:1D0D17:21D9E5:6904AA32
+
+
+2025/10/31 12:23:14 --> HEAD https://ghcr.io/v2/docker/github-builder-test/blobs/sha256:ecb58f9176a603e8800a1e7669b96a58717eb8201f775ae3de20265139cc4ad7
+2025/10/31 12:23:14 HEAD /v2/docker/github-builder-test/blobs/sha256:ecb58f9176a603e8800a1e7669b96a58717eb8201f775ae3de20265139cc4ad7 HTTP/1.1
+Host: ghcr.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Authorization: <redacted>
+
+
+2025/10/31 12:23:14 <-- 404 https://ghcr.io/v2/docker/github-builder-test/blobs/sha256:ecb58f9176a603e8800a1e7669b96a58717eb8201f775ae3de20265139cc4ad7 (47.830432ms)
+2025/10/31 12:23:14 HTTP/2.0 404 Not Found
+Content-Length: 74
+Content-Type: application/json
+Date: Fri, 31 Oct 2025 12:23:14 GMT
+Docker-Distribution-Api-Version: registry/2.0
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+X-Github-Request-Id: 6802:6EC77:1D0D2E:21D9F7:6904AA32
+
+
+2025/10/31 12:23:14 --> POST https://ghcr.io/v2/docker/github-builder-test/blobs/uploads/
+2025/10/31 12:23:14 POST /v2/docker/github-builder-test/blobs/uploads/ HTTP/1.1
+Host: ghcr.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Content-Length: 0
+Authorization: <redacted>
+Content-Type: application/json
+Accept-Encoding: gzip
+
+
+2025/10/31 12:23:14 <-- 202 https://ghcr.io/v2/docker/github-builder-test/blobs/uploads/ (166.290948ms)
+2025/10/31 12:23:14 HTTP/2.0 202 Accepted
+Content-Length: 0
+Content-Type: application/json
+Date: Fri, 31 Oct 2025 12:23:14 GMT
+Docker-Distribution-Api-Version: registry/2.0
+Docker-Upload-Uuid: 46e84f19-fb63-4170-bd9b-f9130303b9f5
+Location: /v2/docker/github-builder-test/blobs/upload/46e84f19-fb63-4170-bd9b-f9130303b9f5
+Range: 0-0
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+X-Github-Request-Id: 6802:6EC77:1D0D35:21DA0A:6904AA32
+
+
+2025/10/31 12:23:14 --> PATCH https://ghcr.io/v2/docker/github-builder-test/blobs/upload/46e84f19-fb63-4170-bd9b-f9130303b9f5
+2025/10/31 12:23:14 PATCH /v2/docker/github-builder-test/blobs/upload/46e84f19-fb63-4170-bd9b-f9130303b9f5 HTTP/1.1
+Host: ghcr.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Content-Length: 10395
+Authorization: <redacted>
+Content-Type: application/octet-stream
+Accept-Encoding: gzip
+
+{"mediaType":"application/vnd.dev.sigstore.bundle.v0.3+json","verificationMaterial":{"certificate":{"rawBytes":"MIIHHTCCBqSgAwIBAgIUKpaCxU56B0xDv34Ze4dstYDm1RowCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUxMDMxMTIyMzEzWhcNMjUxMDMxMTIzMzEzWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEEKtDOSUR6FcaYB9lm8FYt5VABwk+HL0w3t8FQjMLeKAqTuXKWUVsV8HSGFJWuqKxDwKnIB17uPcuAh67YSyCmKOCBcMwggW/MA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUE4+I4uXueR1yT5vjldkrZ4G+hsIwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wgYIGA1UdEQEB/wR4MHaGdGh0dHBzOi8vZ2l0aHViLmNvbS9kb2NrZXIvZ2l0aHViLWJ1aWxkZXItZXhwZXJpbWVudGFsLy5naXRodWIvd29ya2Zsb3dzL2J1aWxkLnltbEByZWZzL2hlYWRzL2J1aWxkLXJldXNhYmxlLXdvcmtmbG93MDkGCisGAQQBg78wAQEEK2h0dHBzOi8vdG9rZW4uYWN0aW9ucy5naXRodWJ1c2VyY29udGVudC5jb20wHwYKKwYBBAGDvzABAgQRd29ya2Zsb3dfZGlzcGF0Y2gwNgYKKwYBBAGDvzABAwQoYTA5ZmM2ZWI4ODM3ZDMwNTQ4YzRkYjI2MDc0YzBiYzY1NTFlOTIxNTAQBgorBgEEAYO/MAEEBAJjaTAoBgorBgEEAYO/MAEFBBpkb2NrZXIvZ2l0aHViLWJ1aWxkZXItdGVzdDAdBgorBgEEAYO/MAEGBA9yZWZzL2hlYWRzL21haW4wOwYKKwYBBAGDvzABCAQtDCtodHRwczovL3Rva2VuLmFjdGlvbnMuZ2l0aHVidXNlcmNvbnRlbnQuY29tMIGEBgorBgEEAYO/MAEJBHYMdGh0dHBzOi8vZ2l0aHViLmNvbS9kb2NrZXIvZ2l0aHViLWJ1aWxkZXItZXhwZXJpbWVudGFsLy5naXRodWIvd29ya2Zsb3dzL2J1aWxkLnltbEByZWZzL2hlYWRzL2J1aWxkLXJldXNhYmxlLXdvcmtmbG93MDgGCisGAQQBg78wAQoEKgwoMGUwZDQ2NWM2ZGNhMzZmNzNlMDc5OGUzMWU2OTE5OTBmOTllNmVjNDAdBgorBgEEAYO/MAELBA8MDWdpdGh1Yi1ob3N0ZWQwPQYKKwYBBAGDvzABDAQvDC1odHRwczovL2dpdGh1Yi5jb20vZG9ja2VyL2dpdGh1Yi1idWlsZGVyLXRlc3QwOAYKKwYBBAGDvzABDQQqDChhMDlmYzZlYjg4MzdkMzA1NDhjNGRiMjYwNzRjMGJjNjU1MWU5MjE1MB8GCisGAQQBg78wAQ4EEQwPcmVmcy9oZWFkcy9tYWluMBoGCisGAQQBg78wAQ8EDAwKMTA0MDU5NDI4NzApBgorBgEEAYO/MAEQBBsMGWh0dHBzOi8vZ2l0aHViLmNvbS9kb2NrZXIwFwYKKwYBBAGDvzABEQQJDAc1NDI5NDcwMGYGCisGAQQBg78wARIEWAxWaHR0cHM6Ly9naXRodWIuY29tL2RvY2tlci9naXRodWItYnVpbGRlci10ZXN0Ly5naXRodWIvd29ya2Zsb3dzL2NpLnltbEByZWZzL2hlYWRzL21haW4wOAYKKwYBBAGDvzABEwQqDChhMDlmYzZlYjg4MzdkMzA1NDhjNGRiMjYwNzRjMGJjNjU1MWU5MjE1MCEGCisGAQQBg78wARQEEwwRd29ya2Zsb3dfZGlzcGF0Y2gwYQYKKwYBBAGDvzABFQRTDFFodHRwczovL2dpdGh1Yi5jb20vZG9ja2VyL2dpdGh1Yi1idWlsZGVyLXRlc3QvYWN0aW9ucy9ydW5zLzE4OTcyMzc1MTYyL2F0dGVtcHRzLzEwGAYKKwYBBAGDvzABFgQKDAhpbnRlcm5hbDCBigYKKwYBBAHWeQIEAgR8BHoAeAB2AN09MGrGxxEyYxkeHJlnNwKiSl643jyt/4eKcoAvKe6OAAABmjo40bwAAAQDAEcwRQIhAOvLpGywq9R5REZs+m+SfutIibjCxCvNVRtdrXBdJzpnAiAj9shT+syMD/WkFMhOnApxjld8CbvrnGPMB3ALVuu+NjAKBggqhkjOPQQDAwNnADBkAjBGgCPgMh5VDaCJuw/bEFaI+O9h5lNpKDuCBbuHH5P0nr18ILlP9nA5WvlfuqY85woCMBBTpzpNuNUeCstWqLovHKVIWt3prQywQJdZbwNepD7FlVnueGEsOAYCqXNbSATdSA=="},"tlogEntries":[{"logIndex":"658949873","logId":{"keyId":"wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="},"kindVersion":{"kind":"dsse","version":"0.0.1"},"integratedTime":"1761913394","inclusionPromise":{"signedEntryTimestamp":"MEUCIQC7ryEY4+TY9EInE26I7nZvRx+syLxTMwNJI2S7iLuUAQIgJ4yr4/v28svJ7kziHPCaLu6XohrhTIL802XjIVAmUfk="},"inclusionProof":{"logIndex":"537045611","rootHash":"S1/6pJxY47NyTTGZbeBhnIx0fF+xGhjbxCNaWO0flKg=","treeSize":"537045613","hashes":["52m5oXN+9Qdrx0bqz6GIEf7hBXYf5ZRBfWYE5DfQSec=","GdUIZawg/YKdziJ5lsSRfsQ4coLJ+iummN72h24BN6E=","l6kiWAqZKP22khjat5v0pOogfPJwNuEygIHQg2Z7cjw=","vvpx7CQg7A3uupiKKPjSCkBCri7fjp4dLUoxPcuLX/Q=","O1dsgL2LCczO6dWokKozaU7xb1SyxmCubP9rGWoeSCs=","p3NjxT2FoaDV5Gjj2Ex4mDeYNCC5ACdtqUEEMPokp2g=","+ukHPMlbS0ZMC0HZZ17V2ggBbu6BbaiRnXpESdr5hcA=","hxeWAKhzQdqOBjOQ8W0MCrMAltMhR69VI25jjbjEb8U=","7eU4MO2rD280XoJuu+dx58GT6AcVjTptjjfcbl2zhx8=","wxy+qRAkZr0OZMsIEhPAvUdGhqViqQbv9IthVGOm3lI=","P6OrPNhquaHIdM/iPT2DlOVW2K/cO02h2h5AGOxNDcE=","T4DqWD42hAtN+vX8jKCWqoC4meE4JekI9LxYGCcPy1M="],"checkpoint":{"envelope":"rekor.sigstore.dev - 1193050959916656506\n537045613\nS1/6pJxY47NyTTGZbeBhnIx0fF+xGhjbxCNaWO0flKg=\n\n— rekor.sigstore.dev wNI9ajBFAiEAxVrgGnOJAFkoEiyl2tfPHoeH+zvpxowfrAHLTOMlLKECIAZt/l7ImJ7zSFRKxttzSLk+yDwO8Ut8aOMac0vUes0a\n"}},"canonicalizedBody":"eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiZHNzZSIsInNwZWMiOnsiZW52ZWxvcGVIYXNoIjp7ImFsZ29yaXRobSI6InNoYTI1NiIsInZhbHVlIjoiNzY3NWVkNjM5ZjlmMjkwMTk3YzIwMzMyNTM2OTE3OGM4ODMzYWIwNGM2YWUzNGU1ZWQyZTZmZjc5YWU2MTlkYiJ9LCJwYXlsb2FkSGFzaCI6eyJhbGdvcml0aG0iOiJzaGEyNTYiLCJ2YWx1ZSI6IjViYzA2MTY5NzgyMGNhNWJiNzYzN2EzMTQ5NmE2ZjIyNTE3NTBhNjRmNTE3NGJkMTJmNGJlMjBkN2QwZTMyMmMifSwic2lnbmF0dXJlcyI6W3sic2lnbmF0dXJlIjoiTUVRQ0lEWEh5cjdXSjAvQTRtK1BZRS8xRWpjazZNYkxoOCs3N2RtQUxLci9JcDd3QWlCeS9XWE9lbmd1MEZpdmVVU1MxMTlRWUZyM0hlMzVndG1UTnhibVNwcHJKUT09IiwidmVyaWZpZXIiOiJMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VoSVZFTkRRbkZUWjBGM1NVSkJaMGxWUzNCaFEzaFZOVFpDTUhoRWRqTTBXbVUwWkhOMFdVUnRNVkp2ZDBObldVbExiMXBKZW1vd1JVRjNUWGNLVG5wRlZrMUNUVWRCTVZWRlEyaE5UV015Ykc1ak0xSjJZMjFWZFZwSFZqSk5ValIzU0VGWlJGWlJVVVJGZUZaNllWZGtlbVJIT1hsYVV6RndZbTVTYkFwamJURnNXa2RzYUdSSFZYZElhR05PVFdwVmVFMUVUWGhOVkVsNVRYcEZlbGRvWTA1TmFsVjRUVVJOZUUxVVNYcE5la1Y2VjJwQlFVMUdhM2RGZDFsSUNrdHZXa2w2YWpCRFFWRlpTVXR2V2tsNmFqQkVRVkZqUkZGblFVVkZTM1JFVDFOVlVqWkdZMkZaUWpsc2JUaEdXWFExVmtGQ2Qyc3JTRXd3ZHpOME9FWUtVV3BOVEdWTFFYRlVkVmhMVjFWV2MxWTRTRk5IUmtwWGRYRkxlRVIzUzI1SlFqRTNkVkJqZFVGb05qZFpVM2xEYlV0UFEwSmpUWGRuWjFjdlRVRTBSd3BCTVZWa1JIZEZRaTkzVVVWQmQwbElaMFJCVkVKblRsWklVMVZGUkVSQlMwSm5aM0pDWjBWR1FsRmpSRUY2UVdSQ1owNVdTRkUwUlVablVWVkZOQ3RKQ2pSMVdIVmxVakY1VkRWMmFteGthM0phTkVjcmFITkpkMGgzV1VSV1VqQnFRa0puZDBadlFWVXpPVkJ3ZWpGWmEwVmFZalZ4VG1wd1MwWlhhWGhwTkZrS1drUTRkMmRaU1VkQk1WVmtSVkZGUWk5M1VqUk5TR0ZIWkVkb01HUklRbnBQYVRoMldqSnNNR0ZJVm1sTWJVNTJZbE01YTJJeVRuSmFXRWwyV2pKc01BcGhTRlpwVEZkS01XRlhlR3RhV0VsMFdsaG9kMXBZU25CaVYxWjFaRWRHYzB4NU5XNWhXRkp2WkZkSmRtUXlPWGxoTWxwellqTmtla3d5U2pGaFYzaHJDa3h1YkhSaVJVSjVXbGRhZWt3eWFHeFpWMUo2VERKS01XRlhlR3RNV0Vwc1pGaE9hRmx0ZUd4TVdHUjJZMjEwYldKSE9UTk5SR3RIUTJselIwRlJVVUlLWnpjNGQwRlJSVVZMTW1nd1pFaENlazlwT0haa1J6bHlXbGMwZFZsWFRqQmhWemwxWTNrMWJtRllVbTlrVjBveFl6SldlVmt5T1hWa1IxWjFaRU0xYWdwaU1qQjNTSGRaUzB0M1dVSkNRVWRFZG5wQlFrRm5VVkprTWpsNVlUSmFjMkl6WkdaYVIyeDZZMGRHTUZreVozZE9aMWxMUzNkWlFrSkJSMFIyZWtGQ0NrRjNVVzlaVkVFMVdtMU5NbHBYU1RSUFJFMHpXa1JOZDA1VVVUUlplbEpyV1dwSk1rMUVZekJaZWtKcFdYcFpNVTVVUm14UFZFbDRUbFJCVVVKbmIzSUtRbWRGUlVGWlR5OU5RVVZGUWtGS2FtRlVRVzlDWjI5eVFtZEZSVUZaVHk5TlFVVkdRa0p3YTJJeVRuSmFXRWwyV2pKc01HRklWbWxNVjBveFlWZDRhd3BhV0VsMFpFZFdlbVJFUVdSQ1oyOXlRbWRGUlVGWlR5OU5RVVZIUWtFNWVWcFhXbnBNTW1oc1dWZFNla3d5TVdoaFZ6UjNUM2RaUzB0M1dVSkNRVWRFQ25aNlFVSkRRVkYwUkVOMGIyUklVbmRqZW05MlRETlNkbUV5Vm5WTWJVWnFaRWRzZG1KdVRYVmFNbXd3WVVoV2FXUllUbXhqYlU1MlltNVNiR0p1VVhVS1dUSTVkRTFKUjBWQ1oyOXlRbWRGUlVGWlR5OU5RVVZLUWtoWlRXUkhhREJrU0VKNlQyazRkbG95YkRCaFNGWnBURzFPZG1KVE9XdGlNazV5V2xoSmRncGFNbXd3WVVoV2FVeFhTakZoVjNocldsaEpkRnBZYUhkYVdFcHdZbGRXZFdSSFJuTk1lVFZ1WVZoU2IyUlhTWFprTWpsNVlUSmFjMkl6WkhwTU1rb3hDbUZYZUd0TWJteDBZa1ZDZVZwWFducE1NbWhzV1ZkU2Vrd3lTakZoVjNoclRGaEtiR1JZVG1oWmJYaHNURmhrZG1OdGRHMWlSemt6VFVSblIwTnBjMGNLUVZGUlFtYzNPSGRCVVc5RlMyZDNiMDFIVlhkYVJGRXlUbGROTWxwSFRtaE5lbHB0VG5wT2JFMUVZelZQUjFWNlRWZFZNazlVUlRWUFZFSnRUMVJzYkFwT2JWWnFUa1JCWkVKbmIzSkNaMFZGUVZsUEwwMUJSVXhDUVRoTlJGZGtjR1JIYURGWmFURnZZak5PTUZwWFVYZFFVVmxMUzNkWlFrSkJSMFIyZWtGQ0NrUkJVWFpFUXpGdlpFaFNkMk42YjNaTU1tUndaRWRvTVZscE5XcGlNakIyV2tjNWFtRXlWbmxNTW1Sd1pFZG9NVmxwTVdsa1YyeHpXa2RXZVV4WVVtd0tZek5SZDA5QldVdExkMWxDUWtGSFJIWjZRVUpFVVZGeFJFTm9hRTFFYkcxWmVscHNXV3BuTkUxNlpHdE5la0V4VGtSb2FrNUhVbWxOYWxsM1RucFNhZ3BOUjBwcVRtcFZNVTFYVlRWTmFrVXhUVUk0UjBOcGMwZEJVVkZDWnpjNGQwRlJORVZGVVhkUVkyMVdiV041T1c5YVYwWnJZM2s1ZEZsWGJIVk5RbTlIQ2tOcGMwZEJVVkZDWnpjNGQwRlJPRVZFUVhkTFRWUkJNRTFFVlRWT1JFazBUbnBCY0VKbmIzSkNaMFZGUVZsUEwwMUJSVkZDUW5OTlIxZG9NR1JJUW5vS1QyazRkbG95YkRCaFNGWnBURzFPZG1KVE9XdGlNazV5V2xoSmQwWjNXVXRMZDFsQ1FrRkhSSFo2UVVKRlVWRktSRUZqTVU1RVNUVk9SR04zVFVkWlJ3cERhWE5IUVZGUlFtYzNPSGRCVWtsRlYwRjRWMkZJVWpCalNFMDJUSGs1Ym1GWVVtOWtWMGwxV1RJNWRFd3lVblpaTW5Sc1kyazVibUZZVW05a1YwbDBDbGx1Vm5CaVIxSnNZMmt4TUZwWVRqQk1lVFZ1WVZoU2IyUlhTWFprTWpsNVlUSmFjMkl6WkhwTU1rNXdURzVzZEdKRlFubGFWMXA2VERKb2JGbFhVbm9LVERJeGFHRlhOSGRQUVZsTFMzZFpRa0pCUjBSMmVrRkNSWGRSY1VSRGFHaE5SR3h0V1hwYWJGbHFaelJOZW1SclRYcEJNVTVFYUdwT1IxSnBUV3BaZHdwT2VsSnFUVWRLYWs1cVZURk5WMVUxVFdwRk1VMURSVWREYVhOSFFWRlJRbWMzT0hkQlVsRkZSWGQzVW1ReU9YbGhNbHB6WWpOa1pscEhiSHBqUjBZd0Nsa3laM2RaVVZsTFMzZFpRa0pCUjBSMmVrRkNSbEZTVkVSR1JtOWtTRkozWTNwdmRrd3laSEJrUjJneFdXazFhbUl5TUhaYVJ6bHFZVEpXZVV3eVpIQUtaRWRvTVZscE1XbGtWMnh6V2tkV2VVeFlVbXhqTTFGMldWZE9NR0ZYT1hWamVUbDVaRmMxZWt4NlJUUlBWR041VFhwak1VMVVXWGxNTWtZd1pFZFdkQXBqU0ZKNlRIcEZkMGRCV1V0TGQxbENRa0ZIUkhaNlFVSkdaMUZMUkVGb2NHSnVVbXhqYlRWb1lrUkRRbWxuV1V0TGQxbENRa0ZJVjJWUlNVVkJaMUk0Q2tKSWIwRmxRVUl5UVU0d09VMUhja2Q0ZUVWNVdYaHJaVWhLYkc1T2QwdHBVMncyTkROcWVYUXZOR1ZMWTI5QmRrdGxOazlCUVVGQ2JXcHZOREJpZDBFS1FVRlJSRUZGWTNkU1VVbG9RVTkyVEhCSGVYZHhPVkkxVWtWYWN5dHRLMU5tZFhSSmFXSnFRM2hEZGs1V1VuUmtjbGhDWkVwNmNHNUJhVUZxT1hOb1ZBb3JjM2xOUkM5WGEwWk5hRTl1UVhCNGFteGtPRU5pZG5KdVIxQk5Rak5CVEZaMWRTdE9ha0ZMUW1kbmNXaHJhazlRVVZGRVFYZE9ia0ZFUW10QmFrSkhDbWREVUdkTmFEVldSR0ZEU25WM0wySkZSbUZKSzA4NWFEVnNUbkJMUkhWRFFtSjFTRWcxVURCdWNqRTRTVXhzVURsdVFUVlhkbXhtZFhGWk9EVjNiME1LVFVKQ1ZIQjZjRTUxVGxWbFEzTjBWM0ZNYjNaSVMxWkpWM1F6Y0hKUmVYZFJTbVJhWW5kT1pYQkVOMFpzVm01MVpVZEZjMDlCV1VOeFdFNWlVMEZVWkFwVFFUMDlDaTB0TFMwdFJVNUVJRU5GVWxSSlJrbERRVlJGTFMwdExTMEsifV19fQ=="}],"timestampVerificationData":{"rfc3161Timestamps":[{"signedTimestamp":"MIICyTADAgEAMIICwAYJKoZIhvcNAQcCoIICsTCCAq0CAQMxDTALBglghkgBZQMEAgEwgbgGCyqGSIb3DQEJEAEEoIGoBIGlMIGiAgEBBgkrBgEEAYO/MAIwMTANBglghkgBZQMEAgEFAAQghJr6SlEcNiabE0P40jFKimwsNQOHA1sYTagKjocwPCsCFQDF5U5dqA6Fl5i00aofySZLmJMi1xgPMjAyNTEwMzExMjIzMTNaMAMCAQGgMqQwMC4xFTATBgNVBAoTDHNpZ3N0b3JlLmRldjEVMBMGA1UEAxMMc2lnc3RvcmUtdHNhoAAxggHaMIIB1gIBATBRMDkxFTATBgNVBAoTDHNpZ3N0b3JlLmRldjEgMB4GA1UEAxMXc2lnc3RvcmUtdHNhLXNlbGZzaWduZWQCFDoTVC8MkGHuvMFDL8uKjosqI4sMMAsGCWCGSAFlAwQCAaCB/DAaBgkqhkiG9w0BCQMxDQYLKoZIhvcNAQkQAQQwHAYJKoZIhvcNAQkFMQ8XDTI1MTAzMTEyMjMxM1owLwYJKoZIhvcNAQkEMSIEIHDsaBIBOVqiV6ClSRGMB0ZnDfKNukLeAHEJmw2+I1iDMIGOBgsqhkiG9w0BCRACLzF/MH0wezB5BCCF+Se8B6tiysO0Q1bBDvyBssaIP9p6uebYcNnROs0FtzBVMD2kOzA5MRUwEwYDVQQKEwxzaWdzdG9yZS5kZXYxIDAeBgNVBAMTF3NpZ3N0b3JlLXRzYS1zZWxmc2lnbmVkAhQ6E1QvDJBh7rzBQy/Lio6LKiOLDDAKBggqhkjOPQQDAgRmMGQCMHnK6uZheOSbX82+RdV2ThCJ48/6J6oMQAcqR0pNWaXYhpriMydi+GPsZODPFt5MkwIwQD/AG1GDnYXRrylo74qsCURwTegurMi7QfPePz11xv0TMKyTC38sDrEsV6OA85xJ"}]}},"dsseEnvelope":{"payload":"eyJfdHlwZSI6Imh0dHBzOi8vaW4tdG90by5pby9TdGF0ZW1lbnQvdjEiLCJzdWJqZWN0IjpbeyJkaWdlc3QiOnsic2hhMjU2IjoiYzZmYzQ1OGNjODcxODYyOGU4ZmI4YjY5OWQyOTkxMDU2NTkwZTBmZWQ0ZWEwZDZmODY1ODM3MDUyMDJiZGNlNCJ9fV0sInByZWRpY2F0ZVR5cGUiOiJodHRwczovL3NpZ3N0b3JlLmRldi9jb3NpZ24vc2lnbi92MSJ9","payloadType":"application/vnd.in-toto+json","signatures":[{"sig":"MEQCIDXHyr7WJ0/A4m+PYE/1Ejck6MbLh8+77dmALKr/Ip7wAiBy/WXOengu0FiveUSS119QYFr3He35gtmTNxbmSpprJQ=="}]}}
+2025/10/31 12:23:15 <-- 202 https://ghcr.io/v2/docker/github-builder-test/blobs/upload/46e84f19-fb63-4170-bd9b-f9130303b9f5 (152.096564ms)
+2025/10/31 12:23:15 HTTP/2.0 202 Accepted
+Content-Length: 0
+Content-Type: application/json
+Date: Fri, 31 Oct 2025 12:23:15 GMT
+Docker-Distribution-Api-Version: registry/2.0
+Docker-Upload-Uuid: 46e84f19-fb63-4170-bd9b-f9130303b9f5
+Location: /v2/docker/github-builder-test/blobs/upload/46e84f19-fb63-4170-bd9b-f9130303b9f5
+Range: 0-10394
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+X-Github-Request-Id: 6802:6EC77:1D0D5D:21DA34:6904AA32
+
+
+2025/10/31 12:23:15 --> PUT https://ghcr.io/v2/docker/github-builder-test/blobs/upload/46e84f19-fb63-4170-bd9b-f9130303b9f5?digest=sha256%3Aecb58f9176a603e8800a1e7669b96a58717eb8201f775ae3de20265139cc4ad7
+2025/10/31 12:23:15 PUT /v2/docker/github-builder-test/blobs/upload/46e84f19-fb63-4170-bd9b-f9130303b9f5?digest=sha256%3Aecb58f9176a603e8800a1e7669b96a58717eb8201f775ae3de20265139cc4ad7 HTTP/1.1
+Host: ghcr.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Content-Length: 0
+Authorization: <redacted>
+Content-Type: application/octet-stream
+Accept-Encoding: gzip
+
+
+2025/10/31 12:23:15 <-- 201 https://ghcr.io/v2/docker/github-builder-test/blobs/upload/46e84f19-fb63-4170-bd9b-f9130303b9f5?digest=sha256%3Aecb58f9176a603e8800a1e7669b96a58717eb8201f775ae3de20265139cc4ad7 (799.390883ms)
+2025/10/31 12:23:15 HTTP/2.0 201 Created
+Content-Length: 0
+Content-Type: application/json
+Date: Fri, 31 Oct 2025 12:23:15 GMT
+Docker-Content-Digest: sha256:ecb58f9176a603e8800a1e7669b96a58717eb8201f775ae3de20265139cc4ad7
+Docker-Distribution-Api-Version: registry/2.0
+Location: /v2/docker/github-builder-test/blobs/sha256:ecb58f9176a603e8800a1e7669b96a58717eb8201f775ae3de20265139cc4ad7
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+X-Github-Request-Id: 6802:6EC77:1D0D7F:21DA60:6904AA33
+
+
+2025/10/31 12:23:15 --> PUT https://ghcr.io/v2/docker/github-builder-test/manifests/sha256:65b138b622eb88020a0e070e14c8d2d71044a000ae190d00d8b9546503486d10
+2025/10/31 12:23:15 PUT /v2/docker/github-builder-test/manifests/sha256:65b138b622eb88020a0e070e14c8d2d71044a000ae190d00d8b9546503486d10 HTTP/1.1
+Host: ghcr.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Content-Length: 880
+Authorization: <redacted>
+Content-Type: application/vnd.oci.image.manifest.v1+json
+Accept-Encoding: gzip
+
+{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","config":{"mediaType":"application/vnd.oci.empty.v1+json","size":2,"digest":"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a","artifactType":"application/vnd.dev.sigstore.bundle.v0.3+json"},"layers":[{"mediaType":"application/vnd.dev.sigstore.bundle.v0.3+json","size":10395,"digest":"sha256:ecb58f9176a603e8800a1e7669b96a58717eb8201f775ae3de20265139cc4ad7"}],"annotations":{"dev.sigstore.bundle.content":"dsse-envelope","dev.sigstore.bundle.predicateType":"https://sigstore.dev/cosign/sign/v1","org.opencontainers.image.created":"2025-10-31T12:23:14Z"},"subject":{"mediaType":"application/vnd.oci.image.manifest.v1+json","size":1380,"digest":"sha256:c6fc458cc8718628e8fb8b699d2991056590e0fed4ea0d6f86583705202bdce4"},"artifactType":"application/vnd.dev.sigstore.bundle.v0.3+json"}
+2025/10/31 12:23:16 <-- 201 https://ghcr.io/v2/docker/github-builder-test/manifests/sha256:65b138b622eb88020a0e070e14c8d2d71044a000ae190d00d8b9546503486d10 (328.504128ms)
+2025/10/31 12:23:16 HTTP/2.0 201 Created
+Content-Length: 0
+Content-Type: application/json
+Date: Fri, 31 Oct 2025 12:23:16 GMT
+Docker-Content-Digest: sha256:65b138b622eb88020a0e070e14c8d2d71044a000ae190d00d8b9546503486d10
+Docker-Distribution-Api-Version: registry/2.0
+Location: /v2/docker/github-builder-test/manifests/sha256:65b138b622eb88020a0e070e14c8d2d71044a000ae190d00d8b9546503486d10
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+X-Github-Request-Id: 6802:6EC77:1D0E11:21DB0F:6904AA33
+
+
+2025/10/31 12:23:16 --> GET https://ghcr.io/v2/docker/github-builder-test/referrers/sha256:c6fc458cc8718628e8fb8b699d2991056590e0fed4ea0d6f86583705202bdce4
+2025/10/31 12:23:16 GET /v2/docker/github-builder-test/referrers/sha256:c6fc458cc8718628e8fb8b699d2991056590e0fed4ea0d6f86583705202bdce4 HTTP/1.1
+Host: ghcr.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Accept: application/vnd.oci.image.index.v1+json
+Authorization: <redacted>
+Accept-Encoding: gzip
+
+
+2025/10/31 12:23:16 <-- 303 https://ghcr.io/v2/docker/github-builder-test/referrers/sha256:c6fc458cc8718628e8fb8b699d2991056590e0fed4ea0d6f86583705202bdce4 (30.18015ms)
+2025/10/31 12:23:16 HTTP/2.0 303 See Other
+Content-Type: application/json
+Date: Fri, 31 Oct 2025 12:23:16 GMT
+Docker-Distribution-Api-Version: registry/2.0
+Location: https://github.com/-/v2/packages/container/package/docker%2Fgithub-builder-test%2Freferrers%2Fsha256
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+X-Github-Request-Id: 6802:6EC77:1D0E57:21DB61:6904AA34
+Content-Length: 0
+
+
+2025/10/31 12:23:16 --> GET https://github.com/-/v2/packages/container/package/docker%2Fgithub-builder-test%2Freferrers%2Fsha256
+2025/10/31 12:23:16 GET /-/v2/packages/container/package/docker%2Fgithub-builder-test%2Freferrers%2Fsha256 HTTP/1.1
+Host: github.com
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Accept: application/vnd.oci.image.index.v1+json
+Referer: https://ghcr.io/v2/docker/github-builder-test/referrers/sha256:c6fc458cc8718628e8fb8b699d2991056590e0fed4ea0d6f86583705202bdce4
+Accept-Encoding: gzip
+
+
+2025/10/31 12:23:16 <-- 404 https://github.com/-/v2/packages/container/package/docker%2Fgithub-builder-test%2Freferrers%2Fsha256 (172.380181ms)
+2025/10/31 12:23:16 HTTP/2.0 404 Not Found
+Content-Length: 9
+Cache-Control: no-cache
+Content-Security-Policy: default-src 'none'; base-uri 'self'; connect-src 'self'; form-action 'self'; img-src 'self' data:; script-src 'self'; style-src 'unsafe-inline'
+Content-Type: text/plain; charset=utf-8
+Date: Fri, 31 Oct 2025 12:23:16 GMT
+Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+Server: github.com
+Set-Cookie: _gh_sess=5WkZnrTo7OblU8ytdh9sksWYIrgLDiUpsHFmKt7hX0ejpvSJfKC6YMVX75sbmHItWZ%2FnibbCURNUzLm7twffWQw3QIgQ5tIBafuKf1zKppawGd4Y7QWUSn23tNFohFfSqiggO0ZbTgDyD%2BAKYECzAmGji0%2F%2FwyDocVOkWVGoxnsA3WOVq4ErmuzJnlfchdC1v59dt8IsHPvzYhkPaj6ViAWWxTVxpkNz5y%2Bg8a2ENV9PtnZmnjBoH4SHuD0CFZJ1eYs%2Fiohsdh%2BiM2gNKP3b8A%3D%3D--jrurs0xR%2FoPBaOwH--n0WTe0LbUeDMussaftfzWA%3D%3D; Path=/; HttpOnly; Secure; SameSite=Lax
+Set-Cookie: _octo=GH1.1.1313354934.1761913396; Path=/; Domain=github.com; Expires=Sat, 31 Oct 2026 12:23:16 GMT; Secure; SameSite=Lax
+Set-Cookie: logged_in=no; Path=/; Domain=github.com; Expires=Sat, 31 Oct 2026 12:23:16 GMT; HttpOnly; Secure; SameSite=Lax
+Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+Vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, X-Requested-With,Accept-Encoding, Accept, X-Requested-With
+X-Content-Type-Options: nosniff
+X-Frame-Options: deny
+X-Github-Request-Id: 6800:1C02A6:2507E6C:32BB7B7:6904AA34
+X-Xss-Protection: 0
+
+Not Found
+2025/10/31 12:23:16 --> GET https://ghcr.io/v2/docker/github-builder-test/manifests/sha256-c6fc458cc8718628e8fb8b699d2991056590e0fed4ea0d6f86583705202bdce4
+2025/10/31 12:23:16 GET /v2/docker/github-builder-test/manifests/sha256-c6fc458cc8718628e8fb8b699d2991056590e0fed4ea0d6f86583705202bdce4 HTTP/1.1
+Host: ghcr.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Accept: application/vnd.oci.image.index.v1+json
+Authorization: <redacted>
+Accept-Encoding: gzip
+
+
+2025/10/31 12:23:16 <-- 404 https://ghcr.io/v2/docker/github-builder-test/manifests/sha256-c6fc458cc8718628e8fb8b699d2991056590e0fed4ea0d6f86583705202bdce4 (49.208935ms)
+2025/10/31 12:23:16 HTTP/2.0 404 Not Found
+Content-Length: 70
+Content-Type: application/json
+Date: Fri, 31 Oct 2025 12:23:16 GMT
+Docker-Distribution-Api-Version: registry/2.0
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+X-Github-Request-Id: 6802:6EC77:1D0E86:21DB97:6904AA34
+
+{"errors":[{"code":"MANIFEST_UNKNOWN","message":"manifest unknown"}]}
+
+2025/10/31 12:23:16 --> PUT https://ghcr.io/v2/docker/github-builder-test/manifests/sha256-c6fc458cc8718628e8fb8b699d2991056590e0fed4ea0d6f86583705202bdce4
+2025/10/31 12:23:16 PUT /v2/docker/github-builder-test/manifests/sha256-c6fc458cc8718628e8fb8b699d2991056590e0fed4ea0d6f86583705202bdce4 HTTP/1.1
+Host: ghcr.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Content-Length: 291
+Authorization: <redacted>
+Content-Type: application/vnd.oci.image.index.v1+json
+Accept-Encoding: gzip
+
+{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[{"mediaType":"application/vnd.oci.image.manifest.v1+json","size":880,"digest":"sha256:65b138b622eb88020a0e070e14c8d2d71044a000ae190d00d8b9546503486d10","artifactType":"application/vnd.oci.empty.v1+json"}]}
+2025/10/31 12:23:16 <-- 201 https://ghcr.io/v2/docker/github-builder-test/manifests/sha256-c6fc458cc8718628e8fb8b699d2991056590e0fed4ea0d6f86583705202bdce4 (291.184483ms)
+2025/10/31 12:23:16 HTTP/2.0 201 Created
+Content-Length: 0
+Content-Type: application/json
+Date: Fri, 31 Oct 2025 12:23:16 GMT
+Docker-Content-Digest: sha256:5fcf33cac79026a9c5f94468df5a92be601e48bb1befc51d067d22f516b87d97
+Docker-Distribution-Api-Version: registry/2.0
+Location: /v2/docker/github-builder-test/manifests/sha256:5fcf33cac79026a9c5f94468df5a92be601e48bb1befc51d067d22f516b87d97
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload

--- a/__tests__/.fixtures/cosign/sign-output3.txt
+++ b/__tests__/.fixtures/cosign/sign-output3.txt
@@ -1,0 +1,329 @@
+25/10/31 12:56:02 --> GET https://index.docker.io/v2/
+2025/10/31 12:56:02 GET /v2/ HTTP/1.1
+Host: index.docker.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Accept-Encoding: gzip
+
+
+2025/10/31 12:56:02 <-- 401 https://index.docker.io/v2/ (66.681248ms)
+2025/10/31 12:56:02 HTTP/2.0 401 Unauthorized
+Content-Length: 87
+Content-Type: application/json
+Date: Fri, 31 Oct 2025 12:56:02 GMT
+Docker-Distribution-Api-Version: registry/2.0
+Strict-Transport-Security: max-age=31536000
+Www-Authenticate: ***"https://auth.docker.io/token",service="registry.docker.io"
+
+{"errors":[{"code":"UNAUTHORIZED","message":"authentication required","detail":null}]}
+
+2025/10/31 12:56:02 --> GET https://auth.docker.io/token?scope=repository%3Acrazymax%2Fgithub-builder-test%3Apull&service=registry.docker.io [body redacted: basic token response contains credentials]
+2025/10/31 12:56:02 GET /token?scope=repository%3Acrazymax%2Fgithub-builder-test%3Apull&service=registry.docker.io HTTP/1.1
+Host: auth.docker.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Authorization: <redacted>
+Accept-Encoding: gzip
+
+
+2025/10/31 12:56:02 <-- 200 https://auth.docker.io/token?scope=repository%3Acrazymax%2Fgithub-builder-test%3Apull&service=registry.docker.io (81.877507ms) [body redacted: basic token response contains credentials]
+2025/10/31 12:56:02 HTTP/2.0 200 OK
+Connection: close
+Content-Type: application/json
+Date: Fri, 31 Oct 2025 12:56:02 GMT
+Strict-Transport-Security: max-age=31536000
+X-Trace-Id: 4107d7c67f22212f177f584ddeb842c6
+X-Trace-Sampled: true
+
+
+2025/10/31 12:56:02 --> GET https://index.docker.io/v2/crazymax/github-builder-test/manifests/sha256:037107d7fd796553702f616bef63d7d54ea1f66a3305650b7b63f48ae0ef825b
+2025/10/31 12:56:02 GET /v2/crazymax/github-builder-test/manifests/sha256:037107d7fd796553702f616bef63d7d54ea1f66a3305650b7b63f48ae0ef825b HTTP/1.1
+Host: index.docker.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Accept: application/vnd.docker.distribution.manifest.v1+json,application/vnd.docker.distribution.manifest.v1+prettyjws,application/vnd.docker.distribution.manifest.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.index.v1+json
+Authorization: <redacted>
+Accept-Encoding: gzip
+
+
+2025/10/31 12:56:02 <-- 200 https://index.docker.io/v2/crazymax/github-builder-test/manifests/sha256:037107d7fd796553702f616bef63d7d54ea1f66a3305650b7b63f48ae0ef825b (57.419407ms)
+2025/10/31 12:56:02 HTTP/2.0 200 OK
+Content-Length: 1380
+Content-Type: application/vnd.oci.image.manifest.v1+json
+Date: Fri, 31 Oct 2025 12:56:02 GMT
+Docker-Content-Digest: sha256:037107d7fd796553702f616bef63d7d54ea1f66a3305650b7b63f48ae0ef825b
+Docker-Distribution-Api-Version: registry/2.0
+Docker-Ratelimit-Source: d2fd3209-1e2e-451f-b428-29c5bbf3b4b7
+Etag: "sha256:037107d7fd796553702f616bef63d7d54ea1f66a3305650b7b63f48ae0ef825b"
+Strict-Transport-Security: max-age=31536000
+
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "artifactType": "application/vnd.docker.attestation.manifest.v1+json",
+  "config": {
+    "mediaType": "application/vnd.oci.empty.v1+json",
+    "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+    "size": 2,
+    "data": "e30="
+  },
+  "layers": [
+    {
+      "mediaType": "application/vnd.in-toto+json",
+      "digest": "sha256:8610c8cf92db274e5228c44ece3bf2468bcfe19e8a92d3adb2afcbbfbb6b169b",
+      "size": 1060,
+      "annotations": {
+        "in-toto.io/predicate-type": "https://spdx.dev/Document"
+      }
+    },
+    {
+      "mediaType": "application/vnd.in-toto+json",
+      "digest": "sha256:1f6a5f284d4750f03d388f000684e3395b6b5006269036d1b2c3369c092aaa94",
+      "size": 81242,
+      "annotations": {
+        "in-toto.io/predicate-type": "https://spdx.dev/Document"
+      }
+    },
+    {
+      "mediaType": "application/vnd.in-toto+json",
+      "digest": "sha256:5ce8b4a314586615e6ae5aea652dbd4ef72086ab77f8b90caacc1a67412804c6",
+      "size": 12957,
+      "annotations": {
+        "in-toto.io/predicate-type": "https://slsa.dev/provenance/v1"
+      }
+    }
+  ],
+  "subject": {
+    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+    "digest": "sha256:81d8ebe81024fdaa4e8f1c410346b0db76c655664db654a878565940661722a1",
+    "size": 476
+  }
+}
+Signing artifact...
+2025/10/31 12:56:02 --> GET https://index.docker.io/v2/
+2025/10/31 12:56:02 GET /v2/ HTTP/1.1
+Host: index.docker.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Accept-Encoding: gzip
+
+
+2025/10/31 12:56:03 <-- 401 https://index.docker.io/v2/ (65.403116ms)
+2025/10/31 12:56:03 HTTP/2.0 401 Unauthorized
+Content-Length: 87
+Content-Type: application/json
+Date: Fri, 31 Oct 2025 12:56:03 GMT
+Docker-Distribution-Api-Version: registry/2.0
+Strict-Transport-Security: max-age=31536000
+Www-Authenticate: ***"https://auth.docker.io/token",service="registry.docker.io"
+
+{"errors":[{"code":"UNAUTHORIZED","message":"authentication required","detail":null}]}
+
+2025/10/31 12:56:03 --> GET https://auth.docker.io/token?scope=repository%3Acrazymax%2Fgithub-builder-test%3Apull&service=registry.docker.io [body redacted: basic token response contains credentials]
+2025/10/31 12:56:03 GET /token?scope=repository%3Acrazymax%2Fgithub-builder-test%3Apull&service=registry.docker.io HTTP/1.1
+Host: auth.docker.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Authorization: <redacted>
+Accept-Encoding: gzip
+
+
+2025/10/31 12:56:03 <-- 200 https://auth.docker.io/token?scope=repository%3Acrazymax%2Fgithub-builder-test%3Apull&service=registry.docker.io (80.031672ms) [body redacted: basic token response contains credentials]
+2025/10/31 12:56:03 HTTP/2.0 200 OK
+Connection: close
+Content-Type: application/json
+Date: Fri, 31 Oct 2025 12:56:03 GMT
+Strict-Transport-Security: max-age=31536000
+X-Trace-Id: 43bd1078547ea5764a91a11ff441f7ec
+X-Trace-Sampled: true
+
+
+2025/10/31 12:56:03 --> HEAD https://index.docker.io/v2/crazymax/github-builder-test/manifests/sha256:037107d7fd796553702f616bef63d7d54ea1f66a3305650b7b63f48ae0ef825b
+2025/10/31 12:56:03 HEAD /v2/crazymax/github-builder-test/manifests/sha256:037107d7fd796553702f616bef63d7d54ea1f66a3305650b7b63f48ae0ef825b HTTP/1.1
+Host: index.docker.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Accept: application/vnd.docker.distribution.manifest.v1+json,application/vnd.docker.distribution.manifest.v1+prettyjws,application/vnd.docker.distribution.manifest.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.index.v1+json
+Authorization: <redacted>
+
+
+2025/10/31 12:56:03 <-- 200 https://index.docker.io/v2/crazymax/github-builder-test/manifests/sha256:037107d7fd796553702f616bef63d7d54ea1f66a3305650b7b63f48ae0ef825b (70.096126ms)
+2025/10/31 12:56:03 HTTP/2.0 200 OK
+Content-Length: 1380
+Content-Type: application/vnd.oci.image.manifest.v1+json
+Date: Fri, 31 Oct 2025 12:56:03 GMT
+Docker-Content-Digest: sha256:037107d7fd796553702f616bef63d7d54ea1f66a3305650b7b63f48ae0ef825b
+Docker-Distribution-Api-Version: registry/2.0
+Docker-Ratelimit-Source: d2fd3209-1e2e-451f-b428-29c5bbf3b4b7
+Etag: "sha256:037107d7fd796553702f616bef63d7d54ea1f66a3305650b7b63f48ae0ef825b"
+Strict-Transport-Security: max-age=31536000
+
+
+2025/10/31 12:56:03 --> GET https://index.docker.io/v2/
+2025/10/31 12:56:03 GET /v2/ HTTP/1.1
+Host: index.docker.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Accept-Encoding: gzip
+
+
+2025/10/31 12:56:03 <-- 401 https://index.docker.io/v2/ (21.659828ms)
+2025/10/31 12:56:03 HTTP/2.0 401 Unauthorized
+Content-Length: 87
+Content-Type: application/json
+Date: Fri, 31 Oct 2025 12:56:03 GMT
+Docker-Distribution-Api-Version: registry/2.0
+Strict-Transport-Security: max-age=31536000
+Www-Authenticate: ***"https://auth.docker.io/token",service="registry.docker.io"
+
+{"errors":[{"code":"UNAUTHORIZED","message":"authentication required","detail":null}]}
+
+2025/10/31 12:56:03 --> GET https://auth.docker.io/token?scope=repository%3Acrazymax%2Fgithub-builder-test%3Apush%2Cpull&service=registry.docker.io [body redacted: basic token response contains credentials]
+2025/10/31 12:56:03 GET /token?scope=repository%3Acrazymax%2Fgithub-builder-test%3Apush%2Cpull&service=registry.docker.io HTTP/1.1
+Host: auth.docker.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Authorization: <redacted>
+Accept-Encoding: gzip
+
+
+2025/10/31 12:56:03 <-- 200 https://auth.docker.io/token?scope=repository%3Acrazymax%2Fgithub-builder-test%3Apush%2Cpull&service=registry.docker.io (38.25606ms) [body redacted: basic token response contains credentials]
+2025/10/31 12:56:03 HTTP/2.0 200 OK
+Connection: close
+Content-Type: application/json
+Date: Fri, 31 Oct 2025 12:56:03 GMT
+Strict-Transport-Security: max-age=31536000
+X-Trace-Id: 20ca8939b8aa180ca68b8bf8ae14b672
+X-Trace-Sampled: false
+
+
+2025/10/31 12:56:03 --> HEAD https://index.docker.io/v2/crazymax/github-builder-test/blobs/sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+2025/10/31 12:56:03 HEAD /v2/crazymax/github-builder-test/blobs/sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a HTTP/1.1
+Host: index.docker.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Authorization: <redacted>
+
+
+2025/10/31 12:56:03 <-- 200 https://index.docker.io/v2/crazymax/github-builder-test/blobs/sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a (27.715324ms)
+2025/10/31 12:56:03 HTTP/2.0 200 OK
+Content-Length: 2
+Accept-Ranges: bytes
+Cache-Control: max-age=31536000
+Content-Type: application/octet-stream
+Date: Fri, 31 Oct 2025 12:56:03 GMT
+Docker-Content-Digest: sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+Docker-Distribution-Api-Version: registry/2.0
+Etag: "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+Strict-Transport-Security: max-age=31536000
+
+
+2025/10/31 12:56:03 --> HEAD https://index.docker.io/v2/crazymax/github-builder-test/blobs/sha256:3417fe347c7333c5f6e46f507ebd6fe83ef14417676c67827d148c2679e3ab45
+2025/10/31 12:56:03 HEAD /v2/crazymax/github-builder-test/blobs/sha256:3417fe347c7333c5f6e46f507ebd6fe83ef14417676c67827d148c2679e3ab45 HTTP/1.1
+Host: index.docker.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Authorization: <redacted>
+
+
+2025/10/31 12:56:03 <-- 404 https://index.docker.io/v2/crazymax/github-builder-test/blobs/sha256:3417fe347c7333c5f6e46f507ebd6fe83ef14417676c67827d148c2679e3ab45 (51.20231ms)
+2025/10/31 12:56:03 HTTP/2.0 404 Not Found
+Content-Length: 157
+Content-Type: application/json
+Date: Fri, 31 Oct 2025 12:56:03 GMT
+Docker-Distribution-Api-Version: registry/2.0
+Strict-Transport-Security: max-age=31536000
+
+
+2025/10/31 12:56:03 --> POST https://index.docker.io/v2/crazymax/github-builder-test/blobs/uploads/
+2025/10/31 12:56:03 POST /v2/crazymax/github-builder-test/blobs/uploads/ HTTP/1.1
+Host: index.docker.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Content-Length: 0
+Authorization: <redacted>
+Content-Type: application/json
+Accept-Encoding: gzip
+
+
+2025/10/31 12:56:03 <-- 202 https://index.docker.io/v2/crazymax/github-builder-test/blobs/uploads/ (94.44866ms)
+2025/10/31 12:56:03 HTTP/2.0 202 Accepted
+Content-Length: 0
+Date: Fri, 31 Oct 2025 12:56:03 GMT
+Docker-Distribution-Api-Version: registry/2.0
+Docker-Upload-Uuid: 9c3f2078-4348-41aa-9cf3-85d557d38ad6
+Location: https://index.docker.io/v2/crazymax/github-builder-test/blobs/uploads/9c3f2078-4348-41aa-9cf3-85d557d38ad6?_state=bBYy5kdM6h2HlGzv-TddrUs0L-qgBO_ah3ECjp4nKM57Ik5hbWUiOiJjcmF6eW1heC9naXRodWItYnVpbGRlci10ZXN0IiwiVVVJRCI6IjljM2YyMDc4LTQzNDgtNDFhYS05Y2YzLTg1ZDU1N2QzOGFkNiIsIk9mZnNldCI6MCwiU3RhcnRlZEF0IjoiMjAyNS0xMC0zMVQxMjo1NjowMy4zMTQ3MTgyMDJaIn0%3D
+Range: 0-0
+Strict-Transport-Security: max-age=31536000
+
+
+2025/10/31 12:56:03 --> PATCH https://index.docker.io/v2/crazymax/github-builder-test/blobs/uploads/9c3f2078-4348-41aa-9cf3-85d557d38ad6?_state=bBYy5kdM6h2HlGzv-TddrUs0L-qgBO_ah3ECjp4nKM57Ik5hbWUiOiJjcmF6eW1heC9naXRodWItYnVpbGRlci10ZXN0IiwiVVVJRCI6IjljM2YyMDc4LTQzNDgtNDFhYS05Y2YzLTg1ZDU1N2QzOGFkNiIsIk9mZnNldCI6MCwiU3RhcnRlZEF0IjoiMjAyNS0xMC0zMVQxMjo1NjowMy4zMTQ3MTgyMDJaIn0%3D
+2025/10/31 12:56:03 PATCH /v2/crazymax/github-builder-test/blobs/uploads/9c3f2078-4348-41aa-9cf3-85d557d38ad6?_state=bBYy5kdM6h2HlGzv-TddrUs0L-qgBO_ah3ECjp4nKM57Ik5hbWUiOiJjcmF6eW1heC9naXRodWItYnVpbGRlci10ZXN0IiwiVVVJRCI6IjljM2YyMDc4LTQzNDgtNDFhYS05Y2YzLTg1ZDU1N2QzOGFkNiIsIk9mZnNldCI6MCwiU3RhcnRlZEF0IjoiMjAyNS0xMC0zMVQxMjo1NjowMy4zMTQ3MTgyMDJaIn0%3D HTTP/1.1
+Host: index.docker.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Content-Length: 10317
+Authorization: <redacted>
+Content-Type: application/octet-stream
+Accept-Encoding: gzip
+
+{"mediaType":"application/vnd.dev.sigstore.bundle.v0.3+json","verificationMaterial":{"certificate":{"rawBytes":"MIIHIDCCBqWgAwIBAgIUeWLksYBhLvx5SodFWCKLaRuJfuswCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjUxMDMxMTI1NjAyWhcNMjUxMDMxMTMwNjAyWjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAErxXfg/Sz/NuXH4Tk405ywbUTqmlAA83MZLpIXpvMB/8kHbBlWZ6PJZyUoRstmxMoRokXBZxzAOxPXKEcL+G5xaOCBcQwggXAMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQU1OfAJD2CI53GFGS6Fe1pTHPIRuUwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wgYIGA1UdEQEB/wR4MHaGdGh0dHBzOi8vZ2l0aHViLmNvbS9kb2NrZXIvZ2l0aHViLWJ1aWxkZXItZXhwZXJpbWVudGFsLy5naXRodWIvd29ya2Zsb3dzL2J1aWxkLnltbEByZWZzL2hlYWRzL2J1aWxkLXJldXNhYmxlLXdvcmtmbG93MDkGCisGAQQBg78wAQEEK2h0dHBzOi8vdG9rZW4uYWN0aW9ucy5naXRodWJ1c2VyY29udGVudC5jb20wHwYKKwYBBAGDvzABAgQRd29ya2Zsb3dfZGlzcGF0Y2gwNgYKKwYBBAGDvzABAwQoYTA5ZmM2ZWI4ODM3ZDMwNTQ4YzRkYjI2MDc0YzBiYzY1NTFlOTIxNTAQBgorBgEEAYO/MAEEBAJjaTAoBgorBgEEAYO/MAEFBBpkb2NrZXIvZ2l0aHViLWJ1aWxkZXItdGVzdDAdBgorBgEEAYO/MAEGBA9yZWZzL2hlYWRzL21haW4wOwYKKwYBBAGDvzABCAQtDCtodHRwczovL3Rva2VuLmFjdGlvbnMuZ2l0aHVidXNlcmNvbnRlbnQuY29tMIGEBgorBgEEAYO/MAEJBHYMdGh0dHBzOi8vZ2l0aHViLmNvbS9kb2NrZXIvZ2l0aHViLWJ1aWxkZXItZXhwZXJpbWVudGFsLy5naXRodWIvd29ya2Zsb3dzL2J1aWxkLnltbEByZWZzL2hlYWRzL2J1aWxkLXJldXNhYmxlLXdvcmtmbG93MDgGCisGAQQBg78wAQoEKgwoMGUwZDQ2NWM2ZGNhMzZmNzNlMDc5OGUzMWU2OTE5OTBmOTllNmVjNDAdBgorBgEEAYO/MAELBA8MDWdpdGh1Yi1ob3N0ZWQwPQYKKwYBBAGDvzABDAQvDC1odHRwczovL2dpdGh1Yi5jb20vZG9ja2VyL2dpdGh1Yi1idWlsZGVyLXRlc3QwOAYKKwYBBAGDvzABDQQqDChhMDlmYzZlYjg4MzdkMzA1NDhjNGRiMjYwNzRjMGJjNjU1MWU5MjE1MB8GCisGAQQBg78wAQ4EEQwPcmVmcy9oZWFkcy9tYWluMBoGCisGAQQBg78wAQ8EDAwKMTA0MDU5NDI4NzApBgorBgEEAYO/MAEQBBsMGWh0dHBzOi8vZ2l0aHViLmNvbS9kb2NrZXIwFwYKKwYBBAGDvzABEQQJDAc1NDI5NDcwMGYGCisGAQQBg78wARIEWAxWaHR0cHM6Ly9naXRodWIuY29tL2RvY2tlci9naXRodWItYnVpbGRlci10ZXN0Ly5naXRodWIvd29ya2Zsb3dzL2NpLnltbEByZWZzL2hlYWRzL21haW4wOAYKKwYBBAGDvzABEwQqDChhMDlmYzZlYjg4MzdkMzA1NDhjNGRiMjYwNzRjMGJjNjU1MWU5MjE1MCEGCisGAQQBg78wARQEEwwRd29ya2Zsb3dfZGlzcGF0Y2gwYQYKKwYBBAGDvzABFQRTDFFodHRwczovL2dpdGh1Yi5jb20vZG9ja2VyL2dpdGh1Yi1idWlsZGVyLXRlc3QvYWN0aW9ucy9ydW5zLzE4OTczMTQ3ODcwL2F0dGVtcHRzLzEwGAYKKwYBBAGDvzABFgQKDAhpbnRlcm5hbDCBiwYKKwYBBAHWeQIEAgR9BHsAeQB3AN09MGrGxxEyYxkeHJlnNwKiSl643jyt/4eKcoAvKe6OAAABmjpW3MsAAAQDAEgwRgIhAKnFJ8ryirUcE6ZRRvYnGuNZnDz+Fv3/xqysZoyzyum8AiEA2O2w71HMFumwABLFr2YSWEyUpyji1RtC6R7RKaBQKKYwCgYIKoZIzj0EAwMDaQAwZgIxAKZiRpu2Ju+CRFmBRxdWFD9oOjne0baJDAj4bNAcyUvW0Il4SzLtioAC0+bNzSWPXgIxAI77k7tGW2HFYOXOCcruJDizctXPyunLJwTO5Snb4K1e47lpA8IFoEYjgH4oUMJ+3A=="},"tlogEntries":[{"logIndex":"658989641","logId":{"keyId":"wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="},"kindVersion":{"kind":"dsse","version":"0.0.1"},"integratedTime":"1761915362","inclusionPromise":{"signedEntryTimestamp":"MEQCIDxVZ/2zgObYpalVsMAgUj+rUR1qW32buFsr3KgDvceLAiAJSU2LAPd+jbiSN9DA6LPiDyf7G2/37AICe8iMDnPXTg=="},"inclusionProof":{"logIndex":"537085379","rootHash":"+ObQpMSSkOrB/SlxhyyoeyZylTSYXNyhKRnlpu+RSZc=","treeSize":"537085380","hashes":["TJquZxCv5Ywd0zgaIGEzrcJq8+QnZSIkPIo9Ds3k340=","YfEohF8hcAm/SiqVqBTZEDjs360Pg7bUdhnwcEpJyqU=","NSGoQV9xb1nxz/ZKpuxv2ZcE12MQzvTs+uDEDaVCNtw=","Xf2jrik49h6ay3mY6DWoHSv2h+eA4YQmJ/tuvl6Y/uc=","dwGEDWVAwwO5qLUQvJcsDA/dQ3yHzjTkgI5q8JfnfNA=","UdMwkKFmSY6L+QPsYEaolMhQBawJ9dBw5He8q3PHo0M=","xgGY2FP9Z7OismH3HnTjRm20s0Bhuo+oc7jg4DFfkpE=","UHUFo9bFcCp5sT5XjtU8o75stbZM3KJvW43mulWjw9c=","P6OrPNhquaHIdM/iPT2DlOVW2K/cO02h2h5AGOxNDcE=","T4DqWD42hAtN+vX8jKCWqoC4meE4JekI9LxYGCcPy1M="],"checkpoint":{"envelope":"rekor.sigstore.dev - 1193050959916656506\n537085380\n+ObQpMSSkOrB/SlxhyyoeyZylTSYXNyhKRnlpu+RSZc=\n\n— rekor.sigstore.dev wNI9ajBGAiEA9SlhCo1gNaIFFCk40NpUj/xhXLwKhVBQux9LqO0+S7cCIQCfEa960Z9ruvuLao0XwCRm5HPM9NAmOLZ+NDXB5Qf/mA==\n"}},"canonicalizedBody":"eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiZHNzZSIsInNwZWMiOnsiZW52ZWxvcGVIYXNoIjp7ImFsZ29yaXRobSI6InNoYTI1NiIsInZhbHVlIjoiODMxMDYyNzZmMTdkNDIyMWVhMjNkZjQ1MDNlNTRiNmU4NWM4NmM5YWM3YzcwMTNiM2E1YzIxNDAxZjU5ZmYzZiJ9LCJwYXlsb2FkSGFzaCI6eyJhbGdvcml0aG0iOiJzaGEyNTYiLCJ2YWx1ZSI6ImQ0MmI1ZTQ1NGU0YWYyNmQwMTZjN2IyYmE3NjVhMWI4ZjM3NTAxMzMyYWE1YzMwY2I3ZGE2ZTM2NGJjOTFmNWYifSwic2lnbmF0dXJlcyI6W3sic2lnbmF0dXJlIjoiTUVVQ0lRQ3BmTUpkV3dobU1IeTNJTnh4VW51QWlET013VmNwRFliVzQwZm55U0YraHdJZ1FZUHlJZWlOSExoVGVaUlh4TnBxSS9VdU96SmRVNUVZbk1UZ1FjVzY1U2M9IiwidmVyaWZpZXIiOiJMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VoSlJFTkRRbkZYWjBGM1NVSkJaMGxWWlZkTWEzTlpRbWhNZG5nMVUyOWtSbGREUzB4aFVuVktablZ6ZDBObldVbExiMXBKZW1vd1JVRjNUWGNLVG5wRlZrMUNUVWRCTVZWRlEyaE5UV015Ykc1ak0xSjJZMjFWZFZwSFZqSk5ValIzU0VGWlJGWlJVVVJGZUZaNllWZGtlbVJIT1hsYVV6RndZbTVTYkFwamJURnNXa2RzYUdSSFZYZElhR05PVFdwVmVFMUVUWGhOVkVreFRtcEJlVmRvWTA1TmFsVjRUVVJOZUUxVVRYZE9ha0Y1VjJwQlFVMUdhM2RGZDFsSUNrdHZXa2w2YWpCRFFWRlpTVXR2V2tsNmFqQkVRVkZqUkZGblFVVnllRmhtWnk5VGVpOU9kVmhJTkZSck5EQTFlWGRpVlZSeGJXeEJRVGd6VFZwTWNFa0tXSEIyVFVJdk9HdElZa0pzVjFvMlVFcGFlVlZ2VW5OMGJYaE5iMUp2YTFoQ1duaDZRVTk0VUZoTFJXTk1LMGMxZUdGUFEwSmpVWGRuWjFoQlRVRTBSd3BCTVZWa1JIZEZRaTkzVVVWQmQwbElaMFJCVkVKblRsWklVMVZGUkVSQlMwSm5aM0pDWjBWR1FsRmpSRUY2UVdSQ1owNVdTRkUwUlVablVWVXhUMlpCQ2twRU1rTkpOVE5IUmtkVE5rWmxNWEJVU0ZCSlVuVlZkMGgzV1VSV1VqQnFRa0puZDBadlFWVXpPVkJ3ZWpGWmEwVmFZalZ4VG1wd1MwWlhhWGhwTkZrS1drUTRkMmRaU1VkQk1WVmtSVkZGUWk5M1VqUk5TR0ZIWkVkb01HUklRbnBQYVRoMldqSnNNR0ZJVm1sTWJVNTJZbE01YTJJeVRuSmFXRWwyV2pKc01BcGhTRlpwVEZkS01XRlhlR3RhV0VsMFdsaG9kMXBZU25CaVYxWjFaRWRHYzB4NU5XNWhXRkp2WkZkSmRtUXlPWGxoTWxwellqTmtla3d5U2pGaFYzaHJDa3h1YkhSaVJVSjVXbGRhZWt3eWFHeFpWMUo2VERKS01XRlhlR3RNV0Vwc1pGaE9hRmx0ZUd4TVdHUjJZMjEwYldKSE9UTk5SR3RIUTJselIwRlJVVUlLWnpjNGQwRlJSVVZMTW1nd1pFaENlazlwT0haa1J6bHlXbGMwZFZsWFRqQmhWemwxWTNrMWJtRllVbTlrVjBveFl6SldlVmt5T1hWa1IxWjFaRU0xYWdwaU1qQjNTSGRaUzB0M1dVSkNRVWRFZG5wQlFrRm5VVkprTWpsNVlUSmFjMkl6WkdaYVIyeDZZMGRHTUZreVozZE9aMWxMUzNkWlFrSkJSMFIyZWtGQ0NrRjNVVzlaVkVFMVdtMU5NbHBYU1RSUFJFMHpXa1JOZDA1VVVUUlplbEpyV1dwSk1rMUVZekJaZWtKcFdYcFpNVTVVUm14UFZFbDRUbFJCVVVKbmIzSUtRbWRGUlVGWlR5OU5RVVZGUWtGS2FtRlVRVzlDWjI5eVFtZEZSVUZaVHk5TlFVVkdRa0p3YTJJeVRuSmFXRWwyV2pKc01HRklWbWxNVjBveFlWZDRhd3BhV0VsMFpFZFdlbVJFUVdSQ1oyOXlRbWRGUlVGWlR5OU5RVVZIUWtFNWVWcFhXbnBNTW1oc1dWZFNla3d5TVdoaFZ6UjNUM2RaUzB0M1dVSkNRVWRFQ25aNlFVSkRRVkYwUkVOMGIyUklVbmRqZW05MlRETlNkbUV5Vm5WTWJVWnFaRWRzZG1KdVRYVmFNbXd3WVVoV2FXUllUbXhqYlU1MlltNVNiR0p1VVhVS1dUSTVkRTFKUjBWQ1oyOXlRbWRGUlVGWlR5OU5RVVZLUWtoWlRXUkhhREJrU0VKNlQyazRkbG95YkRCaFNGWnBURzFPZG1KVE9XdGlNazV5V2xoSmRncGFNbXd3WVVoV2FVeFhTakZoVjNocldsaEpkRnBZYUhkYVdFcHdZbGRXZFdSSFJuTk1lVFZ1WVZoU2IyUlhTWFprTWpsNVlUSmFjMkl6WkhwTU1rb3hDbUZYZUd0TWJteDBZa1ZDZVZwWFducE1NbWhzV1ZkU2Vrd3lTakZoVjNoclRGaEtiR1JZVG1oWmJYaHNURmhrZG1OdGRHMWlSemt6VFVSblIwTnBjMGNLUVZGUlFtYzNPSGRCVVc5RlMyZDNiMDFIVlhkYVJGRXlUbGROTWxwSFRtaE5lbHB0VG5wT2JFMUVZelZQUjFWNlRWZFZNazlVUlRWUFZFSnRUMVJzYkFwT2JWWnFUa1JCWkVKbmIzSkNaMFZGUVZsUEwwMUJSVXhDUVRoTlJGZGtjR1JIYURGWmFURnZZak5PTUZwWFVYZFFVVmxMUzNkWlFrSkJSMFIyZWtGQ0NrUkJVWFpFUXpGdlpFaFNkMk42YjNaTU1tUndaRWRvTVZscE5XcGlNakIyV2tjNWFtRXlWbmxNTW1Sd1pFZG9NVmxwTVdsa1YyeHpXa2RXZVV4WVVtd0tZek5SZDA5QldVdExkMWxDUWtGSFJIWjZRVUpFVVZGeFJFTm9hRTFFYkcxWmVscHNXV3BuTkUxNlpHdE5la0V4VGtSb2FrNUhVbWxOYWxsM1RucFNhZ3BOUjBwcVRtcFZNVTFYVlRWTmFrVXhUVUk0UjBOcGMwZEJVVkZDWnpjNGQwRlJORVZGVVhkUVkyMVdiV041T1c5YVYwWnJZM2s1ZEZsWGJIVk5RbTlIQ2tOcGMwZEJVVkZDWnpjNGQwRlJPRVZFUVhkTFRWUkJNRTFFVlRWT1JFazBUbnBCY0VKbmIzSkNaMFZGUVZsUEwwMUJSVkZDUW5OTlIxZG9NR1JJUW5vS1QyazRkbG95YkRCaFNGWnBURzFPZG1KVE9XdGlNazV5V2xoSmQwWjNXVXRMZDFsQ1FrRkhSSFo2UVVKRlVWRktSRUZqTVU1RVNUVk9SR04zVFVkWlJ3cERhWE5IUVZGUlFtYzNPSGRCVWtsRlYwRjRWMkZJVWpCalNFMDJUSGs1Ym1GWVVtOWtWMGwxV1RJNWRFd3lVblpaTW5Sc1kyazVibUZZVW05a1YwbDBDbGx1Vm5CaVIxSnNZMmt4TUZwWVRqQk1lVFZ1WVZoU2IyUlhTWFprTWpsNVlUSmFjMkl6WkhwTU1rNXdURzVzZEdKRlFubGFWMXA2VERKb2JGbFhVbm9LVERJeGFHRlhOSGRQUVZsTFMzZFpRa0pCUjBSMmVrRkNSWGRSY1VSRGFHaE5SR3h0V1hwYWJGbHFaelJOZW1SclRYcEJNVTVFYUdwT1IxSnBUV3BaZHdwT2VsSnFUVWRLYWs1cVZURk5WMVUxVFdwRk1VMURSVWREYVhOSFFWRlJRbWMzT0hkQlVsRkZSWGQzVW1ReU9YbGhNbHB6WWpOa1pscEhiSHBqUjBZd0Nsa3laM2RaVVZsTFMzZFpRa0pCUjBSMmVrRkNSbEZTVkVSR1JtOWtTRkozWTNwdmRrd3laSEJrUjJneFdXazFhbUl5TUhaYVJ6bHFZVEpXZVV3eVpIQUtaRWRvTVZscE1XbGtWMnh6V2tkV2VVeFlVbXhqTTFGMldWZE9NR0ZYT1hWamVUbDVaRmMxZWt4NlJUUlBWR042VFZSUk0wOUVZM2RNTWtZd1pFZFdkQXBqU0ZKNlRIcEZkMGRCV1V0TGQxbENRa0ZIUkhaNlFVSkdaMUZMUkVGb2NHSnVVbXhqYlRWb1lrUkRRbWwzV1V0TGQxbENRa0ZJVjJWUlNVVkJaMUk1Q2tKSWMwRmxVVUl6UVU0d09VMUhja2Q0ZUVWNVdYaHJaVWhLYkc1T2QwdHBVMncyTkROcWVYUXZOR1ZMWTI5QmRrdGxOazlCUVVGQ2JXcHdWek5OYzBFS1FVRlJSRUZGWjNkU1owbG9RVXR1UmtvNGNubHBjbFZqUlRaYVVsSjJXVzVIZFU1YWJrUjZLMFoyTXk5NGNYbHpXbTk1ZW5sMWJUaEJhVVZCTWs4eWR3bzNNVWhOUm5WdGQwRkNURVp5TWxsVFYwVjVWWEI1YW1reFVuUkRObEkzVWt0aFFsRkxTMWwzUTJkWlNVdHZXa2w2YWpCRlFYZE5SR0ZSUVhkYVowbDRDa0ZMV21sU2NIVXlTblVyUTFKR2JVSlNlR1JYUmtRNWIwOXFibVV3WW1GS1JFRnFOR0pPUVdONVZYWlhNRWxzTkZONlRIUnBiMEZETUN0aVRucFRWMUFLV0dkSmVFRkpOemRyTjNSSFZ6SklSbGxQV0U5RFkzSjFTa1JwZW1OMFdGQjVkVzVNU25kVVR6VlRibUkwU3pGbE5EZHNjRUU0U1VadlJWbHFaMGcwYndwVlRVb3JNMEU5UFFvdExTMHRMVVZPUkNCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2c9PSJ9XX19"}],"timestampVerificationData":{"rfc3161Timestamps":[{"signedTimestamp":"MIICyDADAgEAMIICvwYJKoZIhvcNAQcCoIICsDCCAqwCAQMxDTALBglghkgBZQMEAgEwgbcGCyqGSIb3DQEJEAEEoIGnBIGkMIGhAgEBBgkrBgEEAYO/MAIwMTANBglghkgBZQMEAgEFAAQgj7wG18KmJy9RCtzLI9PTCPIPRAfRHh1tTqlhqVhkiaYCFG1zqBv+eMNfEkElod8xs18Q55unGA8yMDI1MTAzMTEyNTYwMlowAwIBAaAypDAwLjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MRUwEwYDVQQDEwxzaWdzdG9yZS10c2GgADGCAdowggHWAgEBMFEwOTEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MSAwHgYDVQQDExdzaWdzdG9yZS10c2Etc2VsZnNpZ25lZAIUOhNULwyQYe68wUMvy4qOiyojiwwwCwYJYIZIAWUDBAIBoIH8MBoGCSqGSIb3DQEJAzENBgsqhkiG9w0BCRABBDAcBgkqhkiG9w0BCQUxDxcNMjUxMDMxMTI1NjAyWjAvBgkqhkiG9w0BCQQxIgQgKVTgaWhWr7I1zYpmrlqVGyzu4b6Oir3FFDqhAyLPm80wgY4GCyqGSIb3DQEJEAIvMX8wfTB7MHkEIIX5J7wHq2LKw7RDVsEO/IGyxog/2nq55thw2dE6zQW3MFUwPaQ7MDkxFTATBgNVBAoTDHNpZ3N0b3JlLmRldjEgMB4GA1UEAxMXc2lnc3RvcmUtdHNhLXNlbGZzaWduZWQCFDoTVC8MkGHuvMFDL8uKjosqI4sMMAoGCCqGSM49BAMCBGYwZAIwH0nNCWcc2wohSvUuA7n4iyaUsZhfYkNEDLWi4ks/pESeR/exUXFtEFqif7BLFdVUAjBce0IEP7TrMgM5qV+E0RWqzrtBKqUEpcl1QPQl6l7tmuj98m2c0RgvT51d9kIOufs="}]}},"dsseEnvelope":{"payload":"eyJfdHlwZSI6Imh0dHBzOi8vaW4tdG90by5pby9TdGF0ZW1lbnQvdjEiLCJzdWJqZWN0IjpbeyJkaWdlc3QiOnsic2hhMjU2IjoiMDM3MTA3ZDdmZDc5NjU1MzcwMmY2MTZiZWY2M2Q3ZDU0ZWExZjY2YTMzMDU2NTBiN2I2M2Y0OGFlMGVmODI1YiJ9fV0sInByZWRpY2F0ZVR5cGUiOiJodHRwczovL3NpZ3N0b3JlLmRldi9jb3NpZ24vc2lnbi92MSJ9","payloadType":"application/vnd.in-toto+json","signatures":[{"sig":"MEUCIQCpfMJdWwhmMHy3INxxUnuAiDOMwVcpDYbW40fnySF+hwIgQYPyIeiNHLhTeZRXxNpqI/UuOzJdU5EYnMTgQcW65Sc="}]}}
+2025/10/31 12:56:03 <-- 202 https://index.docker.io/v2/crazymax/github-builder-test/blobs/uploads/9c3f2078-4348-41aa-9cf3-85d557d38ad6?_state=bBYy5kdM6h2HlGzv-TddrUs0L-qgBO_ah3ECjp4nKM57Ik5hbWUiOiJjcmF6eW1heC9naXRodWItYnVpbGRlci10ZXN0IiwiVVVJRCI6IjljM2YyMDc4LTQzNDgtNDFhYS05Y2YzLTg1ZDU1N2QzOGFkNiIsIk9mZnNldCI6MCwiU3RhcnRlZEF0IjoiMjAyNS0xMC0zMVQxMjo1NjowMy4zMTQ3MTgyMDJaIn0%3D (197.874528ms)
+2025/10/31 12:56:03 HTTP/2.0 202 Accepted
+Content-Length: 0
+Date: Fri, 31 Oct 2025 12:56:03 GMT
+Docker-Distribution-Api-Version: registry/2.0
+Docker-Upload-Uuid: 9c3f2078-4348-41aa-9cf3-85d557d38ad6
+Location: https://index.docker.io/v2/crazymax/github-builder-test/blobs/uploads/9c3f2078-4348-41aa-9cf3-85d557d38ad6?_state=GjgLb-y2PfTU_gZDztB9ffte4jJ1ijrT7dZUK2anrkp7Ik5hbWUiOiJjcmF6eW1heC9naXRodWItYnVpbGRlci10ZXN0IiwiVVVJRCI6IjljM2YyMDc4LTQzNDgtNDFhYS05Y2YzLTg1ZDU1N2QzOGFkNiIsIk9mZnNldCI6MTAzMTcsIlN0YXJ0ZWRBdCI6IjIwMjUtMTAtMzFUMTI6NTY6MDNaIn0%3D
+Range: 0-10316
+Strict-Transport-Security: max-age=31536000
+
+
+2025/10/31 12:56:03 --> PUT https://index.docker.io/v2/crazymax/github-builder-test/blobs/uploads/9c3f2078-4348-41aa-9cf3-85d557d38ad6?_state=GjgLb-y2PfTU_gZDztB9ffte4jJ1ijrT7dZUK2anrkp7Ik5hbWUiOiJjcmF6eW1heC9naXRodWItYnVpbGRlci10ZXN0IiwiVVVJRCI6IjljM2YyMDc4LTQzNDgtNDFhYS05Y2YzLTg1ZDU1N2QzOGFkNiIsIk9mZnNldCI6MTAzMTcsIlN0YXJ0ZWRBdCI6IjIwMjUtMTAtMzFUMTI6NTY6MDNaIn0%3D&digest=sha256%3A3417fe347c7333c5f6e46f507ebd6fe83ef14417676c67827d148c2679e3ab45
+2025/10/31 12:56:03 PUT /v2/crazymax/github-builder-test/blobs/uploads/9c3f2078-4348-41aa-9cf3-85d557d38ad6?_state=GjgLb-y2PfTU_gZDztB9ffte4jJ1ijrT7dZUK2anrkp7Ik5hbWUiOiJjcmF6eW1heC9naXRodWItYnVpbGRlci10ZXN0IiwiVVVJRCI6IjljM2YyMDc4LTQzNDgtNDFhYS05Y2YzLTg1ZDU1N2QzOGFkNiIsIk9mZnNldCI6MTAzMTcsIlN0YXJ0ZWRBdCI6IjIwMjUtMTAtMzFUMTI6NTY6MDNaIn0%3D&digest=sha256%3A3417fe347c7333c5f6e46f507ebd6fe83ef14417676c67827d148c2679e3ab45 HTTP/1.1
+Host: index.docker.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Content-Length: 0
+Authorization: <redacted>
+Content-Type: application/octet-stream
+Accept-Encoding: gzip
+
+
+2025/10/31 12:56:04 <-- 201 https://index.docker.io/v2/crazymax/github-builder-test/blobs/uploads/9c3f2078-4348-41aa-9cf3-85d557d38ad6?_state=GjgLb-y2PfTU_gZDztB9ffte4jJ1ijrT7dZUK2anrkp7Ik5hbWUiOiJjcmF6eW1heC9naXRodWItYnVpbGRlci10ZXN0IiwiVVVJRCI6IjljM2YyMDc4LTQzNDgtNDFhYS05Y2YzLTg1ZDU1N2QzOGFkNiIsIk9mZnNldCI6MTAzMTcsIlN0YXJ0ZWRBdCI6IjIwMjUtMTAtMzFUMTI6NTY6MDNaIn0%3D&digest=sha256%3A3417fe347c7333c5f6e46f507ebd6fe83ef14417676c67827d148c2679e3ab45 (620.97629ms)
+2025/10/31 12:56:04 HTTP/2.0 201 Created
+Content-Length: 0
+Date: Fri, 31 Oct 2025 12:56:04 GMT
+Docker-Content-Digest: sha256:3417fe347c7333c5f6e46f507ebd6fe83ef14417676c67827d148c2679e3ab45
+Docker-Distribution-Api-Version: registry/2.0
+Location: https://index.docker.io/v2/crazymax/github-builder-test/blobs/sha256:3417fe347c7333c5f6e46f507ebd6fe83ef14417676c67827d148c2679e3ab45
+Strict-Transport-Security: max-age=31536000
+
+
+2025/10/31 12:56:04 --> PUT https://index.docker.io/v2/crazymax/github-builder-test/manifests/sha256:792fbbfd9fb8577a42115b587583ec25257b81aa276c51ec75f42d18b7f4e622
+2025/10/31 12:56:04 PUT /v2/crazymax/github-builder-test/manifests/sha256:792fbbfd9fb8577a42115b587583ec25257b81aa276c51ec75f42d18b7f4e622 HTTP/1.1
+Host: index.docker.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Content-Length: 880
+Authorization: <redacted>
+Content-Type: application/vnd.oci.image.manifest.v1+json
+Accept-Encoding: gzip
+
+{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","config":{"mediaType":"application/vnd.oci.empty.v1+json","size":2,"digest":"sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a","artifactType":"application/vnd.dev.sigstore.bundle.v0.3+json"},"layers":[{"mediaType":"application/vnd.dev.sigstore.bundle.v0.3+json","size":10317,"digest":"sha256:3417fe347c7333c5f6e46f507ebd6fe83ef14417676c67827d148c2679e3ab45"}],"annotations":{"dev.sigstore.bundle.content":"dsse-envelope","dev.sigstore.bundle.predicateType":"https://sigstore.dev/cosign/sign/v1","org.opencontainers.image.created":"2025-10-31T12:56:02Z"},"subject":{"mediaType":"application/vnd.oci.image.manifest.v1+json","size":1380,"digest":"sha256:037107d7fd796553702f616bef63d7d54ea1f66a3305650b7b63f48ae0ef825b"},"artifactType":"application/vnd.dev.sigstore.bundle.v0.3+json"}
+2025/10/31 12:56:04 <-- 201 https://index.docker.io/v2/crazymax/github-builder-test/manifests/sha256:792fbbfd9fb8577a42115b587583ec25257b81aa276c51ec75f42d18b7f4e622 (289.599089ms)
+2025/10/31 12:56:04 HTTP/2.0 201 Created
+Content-Length: 0
+Date: Fri, 31 Oct 2025 12:56:04 GMT
+Docker-Content-Digest: sha256:792fbbfd9fb8577a42115b587583ec25257b81aa276c51ec75f42d18b7f4e622
+Docker-Distribution-Api-Version: registry/2.0
+Docker-Ratelimit-Source: 135.232.232.34
+Location: https://index.docker.io/v2/crazymax/github-builder-test/manifests/sha256:792fbbfd9fb8577a42115b587583ec25257b81aa276c51ec75f42d18b7f4e622
+Oci-Subject: sha256:037107d7fd796553702f616bef63d7d54ea1f66a3305650b7b63f48ae0ef825b
+Strict-Transport-Security: max-age=31536000
+
+
+2025/10/31 12:56:04 --> GET https://index.docker.io/v2/crazymax/github-builder-test/referrers/sha256:037107d7fd796553702f616bef63d7d54ea1f66a3305650b7b63f48ae0ef825b
+2025/10/31 12:56:04 GET /v2/crazymax/github-builder-test/referrers/sha256:037107d7fd796553702f616bef63d7d54ea1f66a3305650b7b63f48ae0ef825b HTTP/1.1
+Host: index.docker.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Accept: application/vnd.oci.image.index.v1+json
+Authorization: <redacted>
+Accept-Encoding: gzip
+
+
+2025/10/31 12:56:04 <-- 200 https://index.docker.io/v2/crazymax/github-builder-test/referrers/sha256:037107d7fd796553702f616bef63d7d54ea1f66a3305650b7b63f48ae0ef825b (51.087239ms)
+2025/10/31 12:56:04 HTTP/2.0 200 OK
+Content-Length: 89
+Content-Type: application/vnd.oci.image.index.v1+json
+Date: Fri, 31 Oct 2025 12:56:04 GMT
+Docker-Distribution-Api-Version: registry/2.0
+Strict-Transport-Security: max-age=31536000
+
+{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[]}

--- a/__tests__/.fixtures/cosign/verify-output-err1.txt
+++ b/__tests__/.fixtures/cosign/verify-output-err1.txt
@@ -1,0 +1,96 @@
+2025/10/31 13:57:03 --> GET https://index.docker.io/v2/
+2025/10/31 13:57:03 GET /v2/ HTTP/1.1
+Host: index.docker.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Accept-Encoding: gzip
+
+
+2025/10/31 13:57:03 <-- 401 https://index.docker.io/v2/ (191.948348ms)
+2025/10/31 13:57:03 HTTP/2.0 401 Unauthorized
+Content-Length: 87
+Content-Type: application/json
+Date: Fri, 31 Oct 2025 13:57:03 GMT
+Docker-Distribution-Api-Version: registry/2.0
+Strict-Transport-Security: max-age=31536000
+Www-Authenticate: ***"https://auth.docker.io/token",service="registry.docker.io"
+
+{"errors":[{"code":"UNAUTHORIZED","message":"authentication required","detail":null}]}
+
+2025/10/31 13:57:03 --> GET https://auth.docker.io/token?scope=repository%3Acrazymax%2Fgithub-builder-test%3Apull&service=registry.docker.io [body redacted: basic token response contains credentials]
+2025/10/31 13:57:03 GET /token?scope=repository%3Acrazymax%2Fgithub-builder-test%3Apull&service=registry.docker.io HTTP/1.1
+Host: auth.docker.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Authorization: <redacted>
+Accept-Encoding: gzip
+
+
+2025/10/31 13:57:03 <-- 200 https://auth.docker.io/token?scope=repository%3Acrazymax%2Fgithub-builder-test%3Apull&service=registry.docker.io (180.01561ms) [body redacted: basic token response contains credentials]
+2025/10/31 13:57:03 HTTP/2.0 200 OK
+Connection: close
+Content-Type: application/json
+Date: Fri, 31 Oct 2025 13:57:03 GMT
+Strict-Transport-Security: max-age=31536000
+X-Trace-Id: 8d63fbce36baf5f2a0c5f2542efa7a7a
+X-Trace-Sampled: false
+
+
+2025/10/31 13:57:03 --> GET https://index.docker.io/v2/crazymax/github-builder-test/referrers/sha256:6cc021c733ae2760b2493f449d9885b1606002962b51a9c4f0d0d1568b6dc5c0
+2025/10/31 13:57:03 GET /v2/crazymax/github-builder-test/referrers/sha256:6cc021c733ae2760b2493f449d9885b1606002962b51a9c4f0d0d1568b6dc5c0 HTTP/1.1
+Host: index.docker.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Accept: application/vnd.oci.image.index.v1+json
+Authorization: <redacted>
+Accept-Encoding: gzip
+
+
+2025/10/31 13:57:03 <-- 200 https://index.docker.io/v2/crazymax/github-builder-test/referrers/sha256:6cc021c733ae2760b2493f449d9885b1606002962b51a9c4f0d0d1568b6dc5c0 (84.160823ms)
+2025/10/31 13:57:03 HTTP/2.0 200 OK
+Content-Length: 89
+Content-Type: application/vnd.oci.image.index.v1+json
+Date: Fri, 31 Oct 2025 13:57:03 GMT
+Docker-Distribution-Api-Version: registry/2.0
+Strict-Transport-Security: max-age=31536000
+
+{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[]}
+
+2025/10/31 13:57:03 --> GET https://index.docker.io/v2/crazymax/github-builder-test/referrers/sha256:6cc021c733ae2760b2493f449d9885b1606002962b51a9c4f0d0d1568b6dc5c0
+2025/10/31 13:57:03 GET /v2/crazymax/github-builder-test/referrers/sha256:6cc021c733ae2760b2493f449d9885b1606002962b51a9c4f0d0d1568b6dc5c0 HTTP/1.1
+Host: index.docker.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Accept: application/vnd.oci.image.index.v1+json
+Authorization: <redacted>
+Accept-Encoding: gzip
+
+
+2025/10/31 13:57:03 <-- 200 https://index.docker.io/v2/crazymax/github-builder-test/referrers/sha256:6cc021c733ae2760b2493f449d9885b1606002962b51a9c4f0d0d1568b6dc5c0 (95.303988ms)
+2025/10/31 13:57:03 HTTP/2.0 200 OK
+Content-Length: 89
+Content-Type: application/vnd.oci.image.index.v1+json
+Date: Fri, 31 Oct 2025 13:57:03 GMT
+Docker-Distribution-Api-Version: registry/2.0
+Strict-Transport-Security: max-age=31536000
+
+{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[]}
+
+2025/10/31 13:57:03 --> GET https://index.docker.io/v2/crazymax/github-builder-test/manifests/sha256-6cc021c733ae2760b2493f449d9885b1606002962b51a9c4f0d0d1568b6dc5c0.sig
+2025/10/31 13:57:03 GET /v2/crazymax/github-builder-test/manifests/sha256-6cc021c733ae2760b2493f449d9885b1606002962b51a9c4f0d0d1568b6dc5c0.sig HTTP/1.1
+Host: index.docker.io
+User-Agent: cosign/v3.0.2 (linux; amd64) go-containerregistry/v0.20.6
+Accept: application/vnd.docker.distribution.manifest.v1+json,application/vnd.docker.distribution.manifest.v1+prettyjws,application/vnd.docker.distribution.manifest.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.index.v1+json
+Authorization: <redacted>
+Accept-Encoding: gzip
+
+
+2025/10/31 13:57:03 <-- 404 https://index.docker.io/v2/crazymax/github-builder-test/manifests/sha256-6cc021c733ae2760b2493f449d9885b1606002962b51a9c4f0d0d1568b6dc5c0.sig (66.155995ms)
+2025/10/31 13:57:03 HTTP/2.0 404 Not Found
+Content-Length: 169
+Content-Type: application/json
+Date: Fri, 31 Oct 2025 13:57:03 GMT
+Docker-Distribution-Api-Version: registry/2.0
+Docker-Ratelimit-Source: d2fd3209-1e2e-451f-b428-29c5bbf3b4b7
+Strict-Transport-Security: max-age=31536000
+
+{"errors":[{"code":"MANIFEST_UNKNOWN","message":"manifest unknown","detail":"unknown tag=sha256-6cc021c733ae2760b2493f449d9885b1606002962b51a9c4f0d0d1568b6dc5c0.sig"}]}
+
+Error: no signatures found
+error during command execution: no signatures found

--- a/__tests__/cosign/cosign.test.ts
+++ b/__tests__/cosign/cosign.test.ts
@@ -15,10 +15,14 @@
  */
 
 import {describe, expect, it, jest, test} from '@jest/globals';
+import fs from 'fs';
+import path from 'path';
 import * as semver from 'semver';
 
 import {Exec} from '../../src/exec';
 import {Cosign} from '../../src/cosign/cosign';
+
+const fixturesDir = path.join(__dirname, '..', '.fixtures');
 
 describe('isAvailable', () => {
   it('checks Cosign is available', async () => {
@@ -59,5 +63,28 @@ describe('versionSatisfies', () => {
   ])('given %p', async (version, range, expected) => {
     const cosign = new Cosign();
     expect(await cosign.versionSatisfies(range, version)).toBe(expected);
+  });
+});
+
+describe('parseCommandOutput', () => {
+  // prettier-ignore
+  test.each([
+    [path.join(fixturesDir, 'cosign', 'sign-output1.txt')],
+    [path.join(fixturesDir, 'cosign', 'sign-output2.txt')],
+    [path.join(fixturesDir, 'cosign', 'sign-output3.txt')],
+  ])('parsing %p', async (fixturePath: string) => {
+    const signResult = Cosign.parseCommandOutput(fs.readFileSync(fixturePath, 'utf-8'));
+    expect(signResult).toBeDefined();
+    expect(signResult.bundle).toBeDefined();
+  });
+
+  // prettier-ignore
+  test.each([
+    [path.join(fixturesDir, 'cosign', 'verify-output-err1.txt')],
+  ])('parsing %p', async (fixturePath: string) => {
+    const signResult = Cosign.parseCommandOutput(fs.readFileSync(fixturePath, 'utf-8'));
+    expect(signResult).toBeDefined();
+    expect(signResult.bundle).toBeUndefined();
+    expect(signResult.errors).toBeDefined();
   });
 });


### PR DESCRIPTION
~needs #820~

<img width="2094" height="343" alt="Image" src="https://github.com/user-attachments/assets/7f04c08f-98b5-45b8-892c-905017fb7c5f" />

* https://oci.dag.dev/?referrers=public.ecr.aws/q3b5f1u4/test-docker-action@sha256:81fc4794339ac8d5546133d13d3c733d0f22fc3d3eb96422f353bef44c9e7e83
* https://oci.dag.dev/?image=public.ecr.aws/q3b5f1u4/test-docker-action@sha256:1c145c30a5e0f7fbd1ec9d6395780ab97731297b9202bc4434cbbb941227fb43

There is is still tlog entries even with `--tlog-upload=false`, seems related to https://github.com/sigstore/cosign/issues/4503.