### PR TITLE
set isolatedModules=true to fix ts-jest TS151002 warning

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "esModuleInterop": true,
     "target": "es6",
     "module": "node16",
+    "isolatedModules": true,
     "strict": true,
     "declaration": true,
     "sourceMap": true,


### PR DESCRIPTION
relates to https://github.com/docker/actions-toolkit/actions/runs/20713423745/job/59458992610#step:3:463

```
#31 14.23 ts-jest[config] (WARN) message TS151002: Using hybrid module kind (Node16/18/Next) is only supported in "isolatedModules: true". Please set "isolatedModules: true" in your tsconfig.json. To disable this message, you can set "diagnostics.ignoreCodes" to include 151002 in your ts-jest config. See more at https://kulshekhar.github.io/ts-jest/docs/getting-started/options/diagnostics
```