### PR TITLE
ci(publish): fix permissions to create GitHub Release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,8 @@
 name: publish
 
 permissions:
-  id-token: write  # required for OIDC
-  contents: read
+  id-token: write # required for OIDC
+  contents: write # required to create GitHub Release
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
relates to https://github.com/docker/actions-toolkit/actions/runs/20717250489/job/59471307719#step:8:12

```
⚠️ GitHub release failed with status: 403
{"message":"Resource not accessible by integration","documentation_url":"https://docs.github.com/rest/releases/releases#generate-release-notes-content-for-a-release","status":"403"}
Skip retry — your GitHub token/PAT does not have the required permission to create a release
⚠️ Unexpected error fetching GitHub release for tag refs/tags/v0.72.0: HttpError: Resource not accessible by integration - https://docs.github.com/rest/releases/releases#generate-release-notes-content-for-a-release
Error: Resource not accessible by integration - https://docs.github.com/rest/releases/releases#generate-release-notes-content-for-a-release
```