### PR TITLE
ci: set 30 minutes timeout to the integration test step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -201,6 +201,7 @@ jobs:
       -
         name: Test
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        timeout-minutes: 30
         with:
           script: |
             const testName = `${{ matrix.test_name }}`;


### PR DESCRIPTION
follow-up https://github.com/docker/actions-toolkit/pull/1085#issuecomment-4260283184