### PR TITLE
docker(install): retry macOS archive installs on transient apt mirror failures

### DIFF
--- a/src/docker/assets.ts
+++ b/src/docker/assets.ts
@@ -250,7 +250,27 @@ provision:
     export DEBIAN_FRONTEND=noninteractive
     if [ "{{srcType}}" == "archive" ]; then
       {
-        curl -fsSL https://get.docker.com | sh -s -- --channel {{srcArchiveChannel}} --version {{srcArchiveVersion}}
+        getDockerScript=$(mktemp)
+        curl --retry 3 --retry-all-errors --retry-delay 5 -fsSL -o "$getDockerScript" https://get.docker.com
+
+        attempt=1
+        max_attempts=3
+        until [ "$attempt" -gt "$max_attempts" ]; do
+          echo "Docker install attempt $attempt/$max_attempts"
+          if sh "$getDockerScript" --channel {{srcArchiveChannel}} --version {{srcArchiveVersion}}; then
+            break
+          fi
+          if [ "$attempt" -eq "$max_attempts" ]; then
+            echo >&2 "Docker install failed after $max_attempts attempts"
+            exit 1
+          fi
+          echo >&2 "Docker install attempt $attempt failed, retrying after $((attempt * 30))s"
+          rm -rf /var/lib/apt/lists/partial/* || true
+          apt-get clean || true
+          sleep $((attempt * 30))
+          attempt=$((attempt + 1))
+        done
+
         sed -i 's|^ExecStart=.*|ExecStart=/usr/bin/dockerd -H fd://{{#if localTCPPort}} -H tcp://0.0.0.0:2375{{/if}} --containerd=/run/containerd/containerd.sock|' /usr/lib/systemd/system/docker.service
         systemctl daemon-reload
         systemctl restart docker


### PR DESCRIPTION
relates to https://github.com/docker/actions-toolkit/actions/runs/24534040516/job/71724508344#step:10:1656

```
Archive install script log
  + curl -fsSL https://get.docker.com/
  + sh -s -- --channel stable --version 29.4.0
  # Executing docker install script, commit: 8fb5881103ac6f2fb404605d6d5b1f84244f3896
  + sh -c apt-get -qq update >/dev/null
  E: Failed to fetch http://security.ubuntu.com/ubuntu/dists/noble-security/universe/binary-amd64/Packages.xz  File has unexpected size (1168996 != 1169356). Mirror sync in progress? [IP: 91.189.91.81 80]
     Hashes of expected file:
      - Filesize:1169356 [weak]
      - SHA256:4e51e49a33aa3620d62a5baa71ebafa3b842126e00f7c127ec0c135dae3ace13
      - SHA1:2426cb1dad6e771311e91b7cf9399f7591e9453e [weak]
      - MD5Sum:0ff540ebd6e0012a67a9c919230dd2c6 [weak]
     Release file created at: Thu, 16 Apr 2026 19:40:19 +0000
  E: Failed to fetch http://security.ubuntu.com/ubuntu/dists/noble-security/universe/i18n/Translation-en.xz  
  E: Some index files failed to download. They have been ignored, or old ones used instead.
  time="2026-04-16T21:25:14Z" level=warning msg="provisioning scripts should not reference the LIMA_CIDATA variables"
```