### PR TITLE
util: add opt-in whitespace preservation for multiline inputs

### DIFF
--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -157,6 +157,28 @@ ccc`
     ]);
   });
 
+  it('preserves trailing new lines when trimming is disabled', async () => {
+    setInput(
+      'secrets',
+      `"PRIVATE_SSH_KEY=TESTESTTESTESTTESTESTTESTEST
+TESTESTTESTESTTESTESTTESTEST
+TESTESTTESTESTTESTESTTESTEST
+
+
+"
+`
+    );
+    const res = Util.getInputList('secrets', {ignoreComma: true, trimWhitespace: false});
+    expect(res).toEqual([
+      `PRIVATE_SSH_KEY=TESTESTTESTESTTESTESTTESTEST
+TESTESTTESTESTTESTESTTESTEST
+TESTESTTESTESTTESTESTTESTEST
+
+
+`
+    ]);
+  });
+
   it('multiline values without quotes', async () => {
     setInput(
       'secrets',

--- a/src/util.ts
+++ b/src/util.ts
@@ -27,11 +27,12 @@ export interface ListOpts {
   comment?: string;
   commentNoInfix?: boolean;
   quote?: string | boolean | Buffer | null;
+  trimWhitespace?: boolean;
 }
 
 export class Util {
   public static getInputList(name: string, opts?: ListOpts): string[] {
-    return this.getList(core.getInput(name), opts);
+    return this.getList(core.getInput(name, {trimWhitespace: opts?.trimWhitespace !== false}), opts);
   }
 
   public static getList(input: string, opts?: ListOpts): string[] {
@@ -64,7 +65,7 @@ export class Util {
       }
     }
 
-    return res.filter(item => item).map(pat => pat.trim());
+    return res.filter(item => item).map(item => (opts?.trimWhitespace === false ? item : item.trim()));
   }
 
   public static getInputNumber(name: string): number | undefined {


### PR DESCRIPTION
relates to https://github.com/docker/build-push-action/issues/1242

The parser now accepts a `trimWhitespace` option and passes it through to both `@actions/core` input loading and the final list normalization step. When the option is not set, the toolkit still trims whitespace exactly as before.

https://github.com/docker/build-push-action/issues/1242 needs a way to preserve the exact bytes of multiline secret values, but baking secret-specific behavior into `actions-toolkit` would have been the wrong abstraction. This keeps the toolkit generic, preserves compatibility for existing callers, and gives downstream actions an explicit escape hatch when trimming is incorrect.