### PR TITLE
fix Handlebars default import interop

### DIFF
--- a/src/docker/install.ts
+++ b/src/docker/install.ts
@@ -20,7 +20,7 @@ import fsp from 'fs/promises';
 import os from 'os';
 import path from 'path';
 import retry from 'async-retry';
-import * as handlebars from 'handlebars';
+import handlebars from 'handlebars';
 import * as core from '@actions/core';
 import * as io from '@actions/io';
 import * as tc from '@actions/tool-cache';

--- a/src/util.ts
+++ b/src/util.ts
@@ -17,7 +17,7 @@
 import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
-import * as handlebars from 'handlebars';
+import handlebars from 'handlebars';
 import * as core from '@actions/core';
 import * as io from '@actions/io';
 import {parse} from 'csv-parse/sync';


### PR DESCRIPTION
The Handlebars imports now use the package default export instead of a namespace import, which matches how the CommonJS package is exposed to emitted ESM code.

Tested with:

```
yarn build
node --input-type=module -e "import {Util} from './lib/util.js'; console.log(Util.compileHandlebars('{{name}}', {}, {name: 'docker'}))"
```