### PR TITLE
sigstore: support explicit trusted root path

### DIFF
--- a/__tests__/sigstore/sigstore.test.itg.ts
+++ b/__tests__/sigstore/sigstore.test.itg.ts
@@ -21,6 +21,7 @@ import * as path from 'path';
 
 import {Buildx} from '../../src/buildx/buildx.js';
 import {Build} from '../../src/buildx/build.js';
+import {ImageTools} from '../../src/buildx/imagetools.js';
 import {Cosign} from '../../src/cosign/cosign.js';
 import {Install as CosignInstall} from '../../src/cosign/install.js';
 import {Docker} from '../../src/docker/docker.js';
@@ -122,11 +123,13 @@ for (const cosignVersion of signAttestationCosignVersions) {
 
 maybe('verifyImageAttestations', () => {
   let sigstore: Sigstore;
+  let cosignBinPath: string;
 
   beforeAll(async () => {
+    cosignBinPath = await installCosign(currentCosignVersion);
     sigstore = new Sigstore({
       cosign: new Cosign({
-        binPath: await installCosign(currentCosignVersion)
+        binPath: cosignBinPath
       })
     });
   }, 100000);
@@ -162,6 +165,31 @@ maybe('verifyImageAttestations', () => {
       expect(res.signatureManifestDigest).toBeDefined();
     }
   });
+
+  it('uses downloaded trusted root', async () => {
+    const image = 'moby/buildkit:master@sha256:84014da3581b2ff2c14cb4f60029cf9caa272b79e58f2e89c651ea6966d7a505';
+    const attestationDigests = await new ImageTools().attestationDigests({
+      name: image,
+      platform: OCI.defaultPlatform()
+    });
+    expect(attestationDigests.length).toEqual(1);
+
+    const trustedRootPath = await Sigstore.downloadTrustedRoot();
+    expect(fs.existsSync(trustedRootPath)).toBe(true);
+    expect(JSON.parse(fs.readFileSync(trustedRootPath, {encoding: 'utf-8'})).mediaType).toBeDefined();
+
+    const trustedRootSigstore = new Sigstore({
+      cosign: new Cosign({
+        binPath: cosignBinPath
+      }),
+      trustedRootPath: trustedRootPath
+    });
+    const verifyResult = await trustedRootSigstore.verifyImageAttestation(`moby/buildkit@${attestationDigests[0]}`, {
+      certificateIdentityRegexp: `^https://github.com/docker/github-builder-experimental/.github/workflows/bake.yml.*$`
+    });
+    expect(verifyResult.cosignArgs.some(arg => arg.startsWith('--trusted-root'))).toBe(false);
+    expect(verifyResult.signatureManifestDigest).toBeDefined();
+  }, 60000);
 });
 
 maybeIdToken('signProvenanceBlobs', () => {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@actions/io": "^3.0.2",
     "@actions/tool-cache": "^4.0.0",
     "@sigstore/bundle": "^5.0.0",
+    "@sigstore/protobuf-specs": "^0.5.0",
     "@sigstore/tuf": "^5.0.0",
     "@sigstore/verify": "^4.1.0",
     "async-retry": "^1.3.3",

--- a/src/sigstore/sigstore.ts
+++ b/src/sigstore/sigstore.ts
@@ -20,6 +20,7 @@ import path from 'path';
 
 import * as core from '@actions/core';
 import {bundleFromJSON, bundleToJSON, type Bundle, type SerializedBundle} from '@sigstore/bundle';
+import {TrustedRoot} from '@sigstore/protobuf-specs';
 import * as tuf from '@sigstore/tuf';
 import {toSignedEntity, toTrustMaterial, Verifier} from '@sigstore/verify';
 
@@ -48,17 +49,37 @@ import {
 export interface SigstoreOpts {
   cosign?: Cosign;
   imageTools?: ImageTools;
+  trustedRootPath?: string;
 }
 
 const COSIGN_PREDICATE_SLSA_PROVENANCE_V1 = 'slsaprovenance1';
+const TUF_TRUSTED_ROOT_RETRY = {retries: 5};
+const TUF_TRUSTED_ROOT_TIMEOUT = 30000;
 
 export class Sigstore {
   private readonly cosign: Cosign;
   private readonly imageTools: ImageTools;
+  private readonly trustedRootPath: string | undefined;
 
   constructor(opts?: SigstoreOpts) {
     this.cosign = opts?.cosign || new Cosign();
     this.imageTools = opts?.imageTools || new ImageTools();
+    this.trustedRootPath = opts?.trustedRootPath;
+  }
+
+  public static async downloadTrustedRoot(trustedRootPath?: string): Promise<string> {
+    trustedRootPath =
+      trustedRootPath ||
+      Context.tmpName({
+        template: 'trusted-root-XXXXXX.json',
+        tmpdir: Context.tmpDir()
+      });
+    core.info(`Writing Sigstore trusted root to ${trustedRootPath}`);
+    fs.mkdirSync(path.dirname(trustedRootPath), {recursive: true});
+    fs.writeFileSync(trustedRootPath, `${JSON.stringify(TrustedRoot.toJSON(await Sigstore.fetchTrustedRoot()), null, 2)}\n`, {
+      encoding: 'utf-8'
+    });
+    return trustedRootPath;
   }
 
   public async signAttestationManifests(opts: SignAttestationManifestsOpts): Promise<Record<string, SignAttestationManifestsResult>> {
@@ -89,6 +110,7 @@ export class Sigstore {
               '--oidc-provider', 'github-actions',
               '--registry-referrers-mode', 'oci-1-1',
               '--new-bundle-format',
+              ...this.trustedRootArgs(),
               ...cosignExtraArgs
             ];
             core.info(`[command]${this.cosign.binPath} ${[...cosignArgs, attestationRef].join(' ')}`);
@@ -180,6 +202,7 @@ export class Sigstore {
       'verify',
       '--experimental-oci11',
       '--new-bundle-format',
+      ...this.trustedRootArgs(),
       '--certificate-oidc-issuer', 'https://token.actions.githubusercontent.com',
       '--certificate-identity-regexp', opts.certificateIdentityRegexp
     ];
@@ -203,7 +226,7 @@ export class Sigstore {
       }
       const verifyResult = Cosign.parseCommandOutput(execRes.stderr.trim());
       return {
-        cosignArgs: cosignArgs,
+        cosignArgs: Sigstore.portableCosignArgs(cosignArgs),
         signatureManifestDigest: verifyResult.signatureManifestDigest!
       };
     }
@@ -222,7 +245,7 @@ export class Sigstore {
       const verifyResult = Cosign.parseCommandOutput(execRes.stderr.trim());
       if (execRes.exitCode === 0) {
         return {
-          cosignArgs: cosignArgs,
+          cosignArgs: Sigstore.portableCosignArgs(cosignArgs),
           signatureManifestDigest: verifyResult.signatureManifestDigest!
         };
       } else {
@@ -277,6 +300,7 @@ export class Sigstore {
             '--statement', p,
             '--type', COSIGN_PREDICATE_SLSA_PROVENANCE_V1,
             '--bundle', bundlePath,
+            ...this.trustedRootArgs(),
             ...cosignExtraArgs
           ];
           core.info(`[command]${this.cosign.binPath} ${[...cosignArgs, artifactPath].join(' ')}`);
@@ -337,6 +361,7 @@ export class Sigstore {
           const cosignArgs = [
             'verify-blob-attestation',
             '--new-bundle-format',
+            ...this.trustedRootArgs(),
             '--certificate-oidc-issuer', 'https://token.actions.githubusercontent.com',
             '--certificate-identity-regexp', opts.certificateIdentityRegexp,
             '--type', opts.predicateType ?? COSIGN_PREDICATE_SLSA_PROVENANCE_V1
@@ -353,7 +378,7 @@ export class Sigstore {
           }
           result[artifactPath] = {
             bundlePath: signedRes.bundlePath,
-            cosignArgs: cosignArgs
+            cosignArgs: Sigstore.portableCosignArgs(cosignArgs)
           };
         }
       });
@@ -366,9 +391,7 @@ export class Sigstore {
     const parsedBundle = JSON.parse(fs.readFileSync(bundlePath, 'utf-8')) as SerializedBundle;
     const bundle = bundleFromJSON(parsedBundle);
 
-    core.info(`Fetching Sigstore TUF trusted root metadata`);
-    const trustedRoot = await tuf.getTrustedRoot();
-    const trustMaterial = toTrustMaterial(trustedRoot);
+    const trustMaterial = toTrustMaterial(await this.trustedRoot());
 
     try {
       core.info(`Verifying artifact signature`);
@@ -408,6 +431,51 @@ export class Sigstore {
 
   private static noTransparencyLog(noTransparencyLog?: boolean): boolean {
     return noTransparencyLog ?? GitHub.context.payload.repository?.private ?? false;
+  }
+
+  private trustedRootArgs(): Array<string> {
+    if (!this.trustedRootPath) {
+      return [];
+    }
+    if (!fs.existsSync(this.trustedRootPath)) {
+      throw new Error(`Sigstore trusted root not found at ${this.trustedRootPath}`);
+    }
+    return [`--trusted-root=${this.trustedRootPath}`];
+  }
+
+  private async trustedRoot(): Promise<TrustedRoot> {
+    if (!this.trustedRootPath) {
+      return await Sigstore.fetchTrustedRoot();
+    }
+    if (!fs.existsSync(this.trustedRootPath)) {
+      throw new Error(`Sigstore trusted root not found at ${this.trustedRootPath}`);
+    }
+    core.info(`Loading Sigstore trusted root from ${this.trustedRootPath}`);
+    return TrustedRoot.fromJSON(JSON.parse(fs.readFileSync(this.trustedRootPath, {encoding: 'utf-8'})));
+  }
+
+  private static async fetchTrustedRoot(): Promise<TrustedRoot> {
+    core.info(`Fetching Sigstore TUF trusted root metadata`);
+    return await tuf.getTrustedRoot({
+      retry: TUF_TRUSTED_ROOT_RETRY,
+      timeout: TUF_TRUSTED_ROOT_TIMEOUT
+    });
+  }
+
+  private static portableCosignArgs(args: Array<string>): Array<string> {
+    const portableArgs: Array<string> = [];
+    for (let i = 0; i < args.length; i++) {
+      const arg = args[i];
+      if (arg === '--trusted-root') {
+        i++;
+        continue;
+      }
+      if (arg.startsWith('--trusted-root=')) {
+        continue;
+      }
+      portableArgs.push(arg);
+    }
+    return portableArgs;
   }
 
   private async cosignSigningConfigArgs(noTransparencyLog?: boolean): Promise<string[]> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -469,6 +469,7 @@ __metadata:
     "@actions/tool-cache": "npm:^4.0.0"
     "@eslint/js": "npm:^9.39.3"
     "@sigstore/bundle": "npm:^5.0.0"
+    "@sigstore/protobuf-specs": "npm:^0.5.0"
     "@sigstore/tuf": "npm:^5.0.0"
     "@sigstore/verify": "npm:^4.1.0"
     "@types/gunzip-maybe": "npm:^1.4.3"


### PR DESCRIPTION
closes #1125

The Sigstore module now accepts an optional `trustedRootPath`, passes it to cosign commands as `--trusted-root`, and uses it for JS verification when provided. When no path is provided, JS verification still fetches trust material through Sigstore TUF.

This keeps TUF as the default source of truth while allowing workflows to materialize trust root data once at runtime and reuse it for verification.