### PR TITLE
publish actions-toolkit with shrinkwrapped dependencies

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,4 +52,6 @@ jobs:
         name: Publish
         run: |
           npm version --no-git-tag-version ${GITHUB_REF#refs/tags/v}
+          npm install --package-lock-only --ignore-scripts --omit=dev
+          npm shrinkwrap
           npm publish --provenance --access public

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "test": "__tests__"
   },
   "files": [
-    "lib"
+    "lib",
+    "npm-shrinkwrap.json"
   ],
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
This change hardens the published `@docker/actions-toolkit` package by making each release include an npm shrinkwrap for its production dependency tree.

The publish workflow now generates a production-only npm lockfile with lifecycle scripts disabled, converts it to `npm-shrinkwrap.json`, and publishes with provenance as before. The package file allowlist now includes `npm-shrinkwrap.json` so the generated shrinkwrap is shipped in the npm package.

This addresses the supply-chain concern raised in https://github.com/docker/github-builder/pull/216#pullrequestreview-4362179133. Exact npm package versions are immutable, but publishing a shrinkwrap also pins the transitive dependency resolution that consumers get when they install `@docker/actions-toolkit`.

More info: https://docs.npmjs.com/cli/v11/configuring-npm/npm-shrinkwrap-json