### PR TITLE
git: correctly extract tag name when commit has multiple decorations

### DIFF
--- a/__tests__/git.test.ts
+++ b/__tests__/git.test.ts
@@ -408,6 +408,50 @@ describe('ref', () => {
     const ref = await Git.ref();
     expect(ref).toEqual('refs/remotes/unusual-format');
   });
+
+  it('returns mocked detached tag ref when commit also has branch decorations', async () => {
+    vi.spyOn(Exec, 'getExecOutput').mockImplementation((cmd, args): Promise<ExecOutput> => {
+      const fullCmd = `${cmd} ${args?.join(' ')}`;
+      let result = '';
+      switch (fullCmd) {
+        case 'git branch --show-current':
+          result = '';
+          break;
+        case 'git show -s --pretty=%D':
+          result = 'HEAD, tag: v8.0.0, origin/release-branch';
+          break;
+      }
+      return Promise.resolve({
+        stdout: result,
+        stderr: '',
+        exitCode: 0
+      });
+    });
+    const ref = await Git.ref();
+    expect(ref).toEqual('refs/tags/v8.0.0');
+  });
+
+  it('returns mocked detached tag ref (shallow clone) when commit also has branch decorations', async () => {
+    vi.spyOn(Exec, 'getExecOutput').mockImplementation((cmd, args): Promise<ExecOutput> => {
+      const fullCmd = `${cmd} ${args?.join(' ')}`;
+      let result = '';
+      switch (fullCmd) {
+        case 'git branch --show-current':
+          result = '';
+          break;
+        case 'git show -s --pretty=%D':
+          result = 'grafted, HEAD, tag: v8.0.0, origin/release-branch';
+          break;
+      }
+      return Promise.resolve({
+        stdout: result,
+        stderr: '',
+        exitCode: 0
+      });
+    });
+    const ref = await Git.ref();
+    expect(ref).toEqual('refs/tags/v8.0.0');
+  });
 });
 
 describe('fullCommit', () => {

--- a/__tests__/git.test.ts
+++ b/__tests__/git.test.ts
@@ -122,6 +122,9 @@ describe('ref', () => {
         case 'git show -s --pretty=%D':
           result = 'HEAD, tag: 8.0.0';
           break;
+        case 'git for-each-ref --format=%(refname) --points-at HEAD refs/tags/':
+          result = 'refs/tags/8.0.0';
+          break;
       }
       return Promise.resolve({
         stdout: result,
@@ -143,6 +146,9 @@ describe('ref', () => {
           break;
         case 'git show -s --pretty=%D':
           result = 'grafted, HEAD, tag: 8.0.0';
+          break;
+        case 'git for-each-ref --format=%(refname) --points-at HEAD refs/tags/':
+          result = 'refs/tags/8.0.0';
           break;
       }
       return Promise.resolve({
@@ -420,6 +426,9 @@ describe('ref', () => {
         case 'git show -s --pretty=%D':
           result = 'HEAD, tag: v8.0.0, origin/release-branch';
           break;
+        case 'git for-each-ref --format=%(refname) --points-at HEAD refs/tags/':
+          result = 'refs/tags/v8.0.0';
+          break;
       }
       return Promise.resolve({
         stdout: result,
@@ -442,6 +451,9 @@ describe('ref', () => {
         case 'git show -s --pretty=%D':
           result = 'grafted, HEAD, tag: v8.0.0, origin/release-branch';
           break;
+        case 'git for-each-ref --format=%(refname) --points-at HEAD refs/tags/':
+          result = 'refs/tags/v8.0.0';
+          break;
       }
       return Promise.resolve({
         stdout: result,
@@ -451,6 +463,31 @@ describe('ref', () => {
     });
     const ref = await Git.ref();
     expect(ref).toEqual('refs/tags/v8.0.0');
+  });
+
+  it('returns mocked detached tag ref when tag name contains a comma', async () => {
+    vi.spyOn(Exec, 'getExecOutput').mockImplementation((cmd, args): Promise<ExecOutput> => {
+      const fullCmd = `${cmd} ${args?.join(' ')}`;
+      let result = '';
+      switch (fullCmd) {
+        case 'git branch --show-current':
+          result = '';
+          break;
+        case 'git show -s --pretty=%D':
+          result = 'HEAD, tag: release,with-comma, origin/release-branch';
+          break;
+        case 'git for-each-ref --format=%(refname) --points-at HEAD refs/tags/':
+          result = 'refs/tags/release,with-comma';
+          break;
+      }
+      return Promise.resolve({
+        stdout: result,
+        stderr: '',
+        exitCode: 0
+      });
+    });
+    const ref = await Git.ref();
+    expect(ref).toEqual('refs/tags/release,with-comma');
   });
 });
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -138,7 +138,7 @@ export class Git {
 
     // Tag refs are formatted as "tag: <tagname>"
     if (ref.startsWith('tag: ')) {
-      return `refs/tags/${ref.slice('tag: '.length).split(',')[0].trim()}`;
+      return await Git.findDetachedTagRef(ref, res);
     }
 
     // Pull request merge refs are formatted as "pull/<number>/<state>"
@@ -199,6 +199,28 @@ export class Git {
     }
 
     throw new Error(`Cannot infer ref from detached HEAD`);
+  }
+
+  private static async findDetachedTagRef(tagDecoration: string, originalRef: string): Promise<string> {
+    const tagRefs = await Git.exec(['for-each-ref', '--format=%(refname)', '--points-at', 'HEAD', 'refs/tags/']);
+    const refs = tagRefs
+      .split('\n')
+      .map(tagRef => tagRef.trim())
+      .filter(tagRef => tagRef.length > 0)
+      .sort((a, b) => b.length - a.length);
+
+    for (const tagRef of refs) {
+      const decoration = `tag: ${tagRef.slice('refs/tags/'.length)}`;
+      if (tagDecoration === decoration || tagDecoration.startsWith(`${decoration}, `)) {
+        return tagRef;
+      }
+    }
+
+    if (refs.length === 1) {
+      return refs[0];
+    }
+
+    throw new Error(`Cannot find detached tag ref in "${originalRef}"`);
   }
 
   private static async findContainingRef(scope: string): Promise<string | undefined> {

--- a/src/git.ts
+++ b/src/git.ts
@@ -138,7 +138,7 @@ export class Git {
 
     // Tag refs are formatted as "tag: <tagname>"
     if (ref.startsWith('tag: ')) {
-      return `refs/tags/${ref.split(':')[1].trim()}`;
+      return `refs/tags/${ref.slice('tag: '.length).split(',')[0].trim()}`;
     }
 
     // Pull request merge refs are formatted as "pull/<number>/<state>"


### PR DESCRIPTION
Updated the tag reference parsing in `Git.ref()` to ensure the method always returns the correct tag ref even if other decorations are present.