### PR TITLE
sigstore: retry transient manifest lookups

### DIFF
--- a/__tests__/buildx/imagetools.test.ts
+++ b/__tests__/buildx/imagetools.test.ts
@@ -49,7 +49,21 @@ beforeEach(() => {
 });
 
 describe('inspectManifest', () => {
-  it('retries transient manifest unknown errors when requested', async () => {
+  // prettier-ignore
+  it.each([
+    [
+      'Docker Hub missing tag',
+      'ERROR: docker.io/library/alpine:codex-definitely-missing: not found'
+    ],
+    [
+      'GHCR missing digest',
+      'ERROR: ghcr.io/docker/actions-toolkit-test@sha256:128e1cfe4e5f76af75df1121fccaf6da0cba412deec293ad988d7ade34499d09: not found'
+    ],
+    [
+      'AWS ECR manifest propagation',
+      'ERROR: httpReadSeeker: failed open: content at https://public.ecr.aws/v2/q3b5f1u4/test-docker-action/manifests/sha256:76bc7984bdcf00ef5af953b7cb3de57ef39101cc091f4913c738b16cfbd26e53 not found: not found'
+    ]
+  ])('retries transient manifest unknown errors when requested (%s)', async (_name, stderr) => {
     vi.useFakeTimers();
 
     const getCommand = vi.fn().mockResolvedValue({
@@ -62,7 +76,7 @@ describe('inspectManifest', () => {
       .mockResolvedValueOnce({
         exitCode: 1,
         stdout: '',
-        stderr: 'ERROR: MANIFEST_UNKNOWN: manifest unknown'
+        stderr: stderr
       })
       .mockResolvedValueOnce({
         exitCode: 0,

--- a/__tests__/sigstore/sigstore.test.itg.ts
+++ b/__tests__/sigstore/sigstore.test.itg.ts
@@ -106,12 +106,14 @@ for (const cosignVersion of signAttestationCosignVersions) {
 
       const signResults = await sigstore.signAttestationManifests({
         imageNames: [imageName],
-        imageDigest: buildDigest!
+        imageDigest: buildDigest!,
+        retryOnManifestUnknown: true
       });
       expect(Object.keys(signResults).length).toEqual(2);
 
       const verifyResults = await sigstore.verifySignedManifests(signResults, {
-        certificateIdentityRegexp: `^https://github.com/docker/actions-toolkit/.github/workflows/test.yml.*$`
+        certificateIdentityRegexp: `^https://github.com/docker/actions-toolkit/.github/workflows/test.yml.*$`,
+        retryOnManifestUnknown: true
       });
       expect(Object.keys(verifyResults).length).toEqual(2);
     }, 200000);

--- a/src/buildx/imagetools.ts
+++ b/src/buildx/imagetools.ts
@@ -207,7 +207,7 @@ export class ImageTools {
         if (!ImageTools.isManifestUnknownError(lastError.message) || attempt === retries - 1) {
           throw lastError;
         }
-        core.info(`buildx imagetools inspect command failed with MANIFEST_UNKNOWN, retrying attempt ${attempt + 1}/${retries}...\n${lastError.message}`);
+        core.info(`buildx imagetools inspect command failed with manifest not found, retrying attempt ${attempt + 1}/${retries}...\n${lastError.message}`);
         await new Promise(res => setTimeout(res, Math.pow(2, attempt) * 100));
       }
     }
@@ -228,6 +228,6 @@ export class ImageTools {
   }
 
   private static isManifestUnknownError(message: string): boolean {
-    return /(MANIFEST_UNKNOWN|manifest unknown|not found: not found)/i.test(message);
+    return /(MANIFEST_UNKNOWN|manifest unknown)/i.test(message) || /:\s*not found$/i.test(message);
   }
 }

--- a/src/sigstore/sigstore.ts
+++ b/src/sigstore/sigstore.ts
@@ -177,7 +177,8 @@ export class Sigstore {
         const verifyResult = await this.verifyImageAttestation(attestationRef, {
           certificateIdentityRegexp: opts.certificateIdentityRegexp,
           noTransparencyLog: opts.noTransparencyLog || !signedRes.tlogID,
-          retryOnManifestUnknown: opts.retryOnManifestUnknown
+          retryOnManifestUnknown: opts.retryOnManifestUnknown,
+          retryLimit: opts.retryLimit
         });
         core.info(`Signature manifest verified: https://oci.dag.dev/?image=${signedRes.imageName}@${verifyResult.signatureManifestDigest}`);
         result[attestationRef] = verifyResult;


### PR DESCRIPTION
This makes Sigstore attestation signing and verification more tolerant of transient registry propagation failures when `docker buildx imagetools inspect` cannot immediately resolve a just-pushed manifest.