### PR TITLE
cache: avoid hosted tool cache restore races

### DIFF
--- a/__tests__/cache.test.ts
+++ b/__tests__/cache.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Copyright 2026 actions-toolkit authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import * as cache from '@actions/cache';
+import * as tc from '@actions/tool-cache';
+
+import {Cache} from '../src/cache.js';
+
+vi.mock('@actions/cache', () => ({
+  isFeatureAvailable: vi.fn(),
+  restoreCache: vi.fn(),
+  saveCache: vi.fn()
+}));
+
+vi.mock('@actions/tool-cache', () => ({
+  cacheDir: vi.fn(),
+  find: vi.fn()
+}));
+
+const cacheFile = 'docker-buildx';
+const htcName = 'buildx-dl-bin';
+const htcVersion = '1.2.3';
+
+let tmpDir: string;
+let baseCacheDir: string;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  tmpDir = fs.mkdtempSync(path.join(process.env.TEMP || os.tmpdir(), 'cache-'));
+  baseCacheDir = path.join(tmpDir, '.cache');
+
+  vi.mocked(cache.isFeatureAvailable).mockReturnValue(true);
+  vi.mocked(cache.restoreCache).mockResolvedValue(undefined);
+  vi.mocked(cache.saveCache).mockResolvedValue(1);
+  vi.mocked(tc.find).mockReturnValue('');
+  vi.mocked(tc.cacheDir).mockResolvedValue(path.join(tmpDir, 'hosted-tool-cache'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, {recursive: true, force: true});
+});
+
+describe('cache', () => {
+  it('returns the restored GitHub Actions cache file when hosted tool cache seeding succeeds', async () => {
+    vi.mocked(cache.restoreCache).mockImplementation(async paths => {
+      fs.writeFileSync(path.join(paths[0], cacheFile), 'buildx');
+      return 'cache-key';
+    });
+
+    const c = new Cache({
+      htcName,
+      htcVersion,
+      baseCacheDir,
+      cacheFile
+    });
+
+    const restoredPath = await c.find();
+
+    expect(restoredPath).toEqual(expectedCachePath());
+    expect(fs.readFileSync(restoredPath, 'utf8')).toEqual('buildx');
+    expect(tc.cacheDir).toHaveBeenCalledWith(expectedCacheDir(), htcName, htcVersion, cachePlatform());
+  });
+
+  it('returns the restored GitHub Actions cache file when hosted tool cache seeding fails', async () => {
+    vi.mocked(cache.restoreCache).mockImplementation(async paths => {
+      fs.writeFileSync(path.join(paths[0], cacheFile), 'buildx');
+      return 'cache-key';
+    });
+    vi.mocked(tc.cacheDir).mockRejectedValue(new Error('hosted tool cache unavailable'));
+
+    const c = new Cache({
+      htcName,
+      htcVersion,
+      baseCacheDir,
+      cacheFile
+    });
+
+    const restoredPath = await c.find();
+
+    expect(restoredPath).toEqual(expectedCachePath());
+    expect(fs.readFileSync(restoredPath, 'utf8')).toEqual('buildx');
+  });
+
+  it('returns empty when the restored GitHub Actions cache file is missing', async () => {
+    vi.mocked(cache.restoreCache).mockResolvedValue('cache-key');
+
+    const c = new Cache({
+      htcName,
+      htcVersion,
+      baseCacheDir,
+      cacheFile
+    });
+
+    const restoredPath = await c.find();
+
+    expect(restoredPath).toEqual('');
+    expect(tc.cacheDir).not.toHaveBeenCalled();
+  });
+
+  it('saves the local cache file when hosted tool cache seeding fails', async () => {
+    vi.mocked(tc.cacheDir).mockRejectedValue(new Error('hosted tool cache unavailable'));
+    const sourcePath = path.join(tmpDir, 'source-buildx');
+    fs.writeFileSync(sourcePath, 'buildx');
+
+    const c = new Cache({
+      htcName,
+      htcVersion,
+      baseCacheDir,
+      cacheFile
+    });
+
+    const savedPath = await c.save(sourcePath, true);
+
+    expect(savedPath).toEqual(expectedCachePath());
+    expect(fs.readFileSync(savedPath, 'utf8')).toEqual('buildx');
+    expect(cache.saveCache).toHaveBeenCalledWith([expectedCacheDir()], `${htcName}-${htcVersion}-${cachePlatform()}`);
+  });
+});
+
+function expectedCacheDir(): string {
+  return path.join(baseCacheDir, htcVersion, cachePlatform());
+}
+
+function expectedCachePath(): string {
+  return path.join(expectedCacheDir(), cacheFile);
+}
+
+function cachePlatform(): string {
+  const arm_version = (process.config.variables as {arm_version?: string}).arm_version;
+  return `${os.platform()}-${os.arch()}${arm_version ? 'v' + arm_version : ''}`;
+}

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -59,8 +59,10 @@ export class Cache {
     core.debug(`Cache.save ${file}`);
     const cachePath = this.copyToCache(file);
 
-    const htcPath = await tc.cacheDir(this.cacheDir, this.opts.htcName, this.opts.htcVersion, this.platform());
-    core.debug(`Cache.save cached to hosted tool cache ${htcPath}`);
+    const htcPath = await this.cacheToHostedToolCache();
+    if (htcPath) {
+      core.debug(`Cache.save cached to hosted tool cache ${htcPath}`);
+    }
 
     if (!this.ghaNoCache && cache.isFeatureAvailable()) {
       if (skipState) {
@@ -87,7 +89,7 @@ export class Cache {
 
   public async find(): Promise<string> {
     try {
-      let htcPath = tc.find(this.opts.htcName, this.opts.htcVersion, this.platform());
+      const htcPath = tc.find(this.opts.htcName, this.opts.htcVersion, this.platform());
       if (htcPath) {
         core.info(`Restored from hosted tool cache ${htcPath}`);
         return this.copyToCache(`${htcPath}/${this.opts.cacheFile}`);
@@ -96,9 +98,15 @@ export class Cache {
         core.debug(`GitHub Actions cache feature available`);
         if (await cache.restoreCache([this.cacheDir], this.ghaCacheKey)) {
           core.info(`Restored ${this.ghaCacheKey} from GitHub Actions cache`);
-          htcPath = await tc.cacheDir(this.cacheDir, this.opts.htcName, this.opts.htcVersion, this.platform());
-          core.info(`Cached to hosted tool cache ${htcPath}`);
-          return this.copyToCache(`${htcPath}/${this.opts.cacheFile}`);
+          if (!fs.existsSync(this.cachePath)) {
+            core.warning(`Cache file ${this.cachePath} does not exist`);
+            return '';
+          }
+          const htcCachePath = await this.cacheToHostedToolCache();
+          if (htcCachePath) {
+            core.info(`Cached to hosted tool cache ${htcCachePath}`);
+          }
+          return this.cachePath;
         }
       } else if (this.ghaNoCache) {
         core.info(`GitHub Actions cache disabled`);
@@ -139,6 +147,15 @@ export class Cache {
     core.info(`Copying ${file} to ${this.cachePath}`);
     fs.copyFileSync(file, this.cachePath);
     return this.cachePath;
+  }
+
+  private async cacheToHostedToolCache(): Promise<string> {
+    try {
+      return await tc.cacheDir(this.cacheDir, this.opts.htcName, this.opts.htcVersion, this.platform());
+    } catch (e) {
+      core.info(`Failed to cache to hosted tool cache: ${e}`);
+    }
+    return '';
   }
 
   private platform(): string {


### PR DESCRIPTION
fixes https://github.com/docker/setup-buildx-action/issues/479

Return the GitHub Actions cache restore path directly after verifying the restored file exists, and treat hosted tool-cache seeding as best effort. This avoids failing setup actions when hosted tool-cache files are not immediately visible after a successful cache restore.