### PR TITLE
github: helper to suspend workflow commands while logging

### DIFF
--- a/__tests__/github/github.test.ts
+++ b/__tests__/github/github.test.ts
@@ -272,6 +272,47 @@ describe('actionsRuntimeToken', () => {
   });
 });
 
+describe('printUntrusted', () => {
+  afterEach(() => {
+    vi.mocked(core.info).mockReset();
+  });
+
+  test.each([
+    {name: 'plain text', message: 'build metadata'},
+    {name: 'empty text', message: ''},
+    {name: 'workflow commands', message: 'commit message\n##[error]not a real error\n##[stop-commands]attacker-token\n::warning::not a real warning'},
+    {name: 'JSON metadata', message: JSON.stringify({message: 'commit message\n##[error]not a real error'}, null, 2)}
+  ])('prints $name unchanged with commands suspended', ({message}) => {
+    GitHub.printUntrusted(message);
+    const calls = vi.mocked(core.info).mock.calls;
+    const token = calls[0][0].slice('::stop-commands::'.length);
+    expect(token).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+    expect(calls).toEqual([[`::stop-commands::${token}`], [message], [`::${token}::`]]);
+  });
+
+  it('uses a new token for each call', () => {
+    GitHub.printUntrusted('first');
+    GitHub.printUntrusted('second');
+    const calls = vi.mocked(core.info).mock.calls;
+    expect(calls).toHaveLength(6);
+    expect(calls[0][0]).not.toBe(calls[3][0]);
+  });
+
+  it('resumes commands and propagates the error if printing throws', () => {
+    const error = new Error('log write failed');
+    vi.mocked(core.info)
+      .mockImplementationOnce(() => {})
+      .mockImplementationOnce(() => {
+        throw error;
+      });
+
+    expect(() => GitHub.printUntrusted('metadata')).toThrow(error);
+    const calls = vi.mocked(core.info).mock.calls;
+    const token = calls[0][0].slice('::stop-commands::'.length);
+    expect(calls).toEqual([[`::stop-commands::${token}`], ['metadata'], [`::${token}::`]]);
+  });
+});
+
 describe('printActionsRuntimeTokenACs', () => {
   const originalEnv = process.env;
   beforeEach(() => {

--- a/src/github/github.ts
+++ b/src/github/github.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import * as crypto from 'crypto';
 import * as core from '@actions/core';
 import * as github from '@actions/github';
 import * as httpm from '@actions/http-client';
@@ -145,6 +146,16 @@ export class GitHub {
   static get actionsRuntimeToken(): GitHubActionsRuntimeToken | undefined {
     const token = process.env['ACTIONS_RUNTIME_TOKEN'] || '';
     return token ? (jwtDecode<JwtPayload>(token) as GitHubActionsRuntimeToken) : undefined;
+  }
+
+  public static printUntrusted(message: string): void {
+    const token = crypto.randomUUID();
+    core.info(`::stop-commands::${token}`); // https://github.com/actions/runner/blob/602c0085328df8cb595fc2641d69f640a11377a4/src/Runner.Worker/ActionCommandManager.cs#L108-L124
+    try {
+      core.info(message);
+    } finally {
+      core.info(`::${token}::`);
+    }
   }
 
   public static async printActionsRuntimeTokenACs() {


### PR DESCRIPTION
relates to https://github.com/docker/build-push-action/issues/1612

Introduce `GitHub.printUntrusted` to print text unchanged while workflow command processing is suspended. Use a fresh random token for each call and restore processing in a finally block so logging errors propagate without leaving commands disabled.