### PR TITLE
ci: isolate the update-deps npm install from repository dependencies

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -59,9 +59,11 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
+            const path = require('path');
             await core.group(`Install npm deps`, async () => {
               await exec.exec('npm', [
                 'install',
+                '--prefix', path.join(process.env.RUNNER_TEMP, 'update-deps'),
                 '--loglevel=error',
                 '--no-save',
                 '--package-lock=false',
@@ -83,7 +85,7 @@ jobs:
           script: |
             const fs = require('fs');
             const path = require('path');
-            const semver = require('semver');
+            const semver = require(path.join(process.env.RUNNER_TEMP, 'update-deps', 'node_modules', 'semver'));
 
             const dep = core.getInput('dep');
 


### PR DESCRIPTION
relates to https://github.com/docker/actions-toolkit/actions/runs/34327805504/job/102389029440#step:4:26

```
[5](https://github.com/docker/actions-toolkit/actions/runs/34327805504/job/102389029440#step:4:26)
  /usr/local/bin/npm install --loglevel=error --no-save --package-lock=false --ignore-scripts --omit=dev --prefer-offline --fund=false --audit=false semver@7.8.3
  npm error Cannot read properties of null (reading 'edgesOut')
  npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-09-09T08_12_02_838Z-debug-0.log
```

Install semver in the runner temporary directory and load it explicitly from there. This avoids processing the toolkit dependency tree and triggering the npm edgesOut resolver failure.