### PR TITLE
buildx: add a shared helper to extract error summaries

### DIFF
--- a/__tests__/buildx/buildx.test.ts
+++ b/__tests__/buildx/buildx.test.ts
@@ -150,6 +150,177 @@ describe('parseVersion', () => {
   });
 });
 
+describe('getErrorMessage', () => {
+  test.each([
+    {
+      name: 'attestation error followed by driver guidance',
+      stderr: [
+        'ERROR: failed to build: Attestation is not supported for the docker driver.',
+        'Switch to a different driver, or turn on the containerd image store, and try again.',
+        'Learn more at https://docs.docker.com/go/attestations/'
+      ].join('\n'),
+      expected: 'failed to build: Attestation is not supported for the docker driver.'
+    },
+    {
+      name: 'cache export error followed by driver guidance',
+      stderr: [
+        'ERROR: failed to build: Cache export is not supported for the docker driver.',
+        'Switch to a different driver, or turn on the containerd image store, and try again.',
+        'Learn more at https://docs.docker.com/go/build-cache-backends/'
+      ].join('\n'),
+      expected: 'failed to build: Cache export is not supported for the docker driver.'
+    },
+    {
+      // https://github.com/docker/build-push-action/issues/1433
+      name: 'build summary after a vertex error',
+      stderr: [
+        '#11 ERROR: process "/bin/sh -c sha256sum --check license.sha256sum" did not complete successfully: exit code: 1',
+        'ERROR: failed to build: failed to solve: process "/bin/sh -c sha256sum --check license.sha256sum" did not complete successfully: exit code: 1'
+      ].join('\n'),
+      expected: 'failed to build: failed to solve: process "/bin/sh -c sha256sum --check license.sha256sum" did not complete successfully: exit code: 1'
+    },
+    {
+      // https://github.com/docker/bake-action/issues/306
+      name: 'bake cache exporter error',
+      stderr: 'ERROR: failed to solve: unknown cache exporter: "gha,mode=max"\n',
+      expected: 'failed to solve: unknown cache exporter: "gha,mode=max"'
+    },
+    {
+      // https://github.com/docker/bake-action/issues/262
+      name: 'bake git error followed by subprocess stderr',
+      stderr: ['ERROR: failed to solve: failed to checkout remote https://github.com/vivodi/docker-flexget.git: git stderr:', 'fatal: unable to read tree (569a8e0674b0f11330577cddb340fbc67871e4f2)', ': exit status 128'].join('\n'),
+      expected: 'failed to solve: failed to checkout remote https://github.com/vivodi/docker-flexget.git: git stderr:'
+    },
+    {
+      // https://github.com/docker/setup-buildx-action/issues/255
+      name: 'builder creation error',
+      stderr:
+        'ERROR: could not create a builder instance with TLS data loaded from environment. Please use `docker context create <context-name>` to create a context for current environment and then create a builder instance with `docker buildx create <context-name>`\n',
+      expected:
+        'could not create a builder instance with TLS data loaded from environment. Please use `docker context create <context-name>` to create a context for current environment and then create a builder instance with `docker buildx create <context-name>`'
+    },
+    {
+      // https://github.com/docker/build-push-action/issues/264
+      name: 'older Buildx error without a prefix',
+      stderr: ['#1 DONE 0.0s', 'failed to solve: rpc error: code = Unknown desc = failed to solve with frontend dockerfile.v0: failed to read dockerfile: open /tmp/buildkit-mount967127233/build.Dockerfile: no such file or directory'].join(
+        '\n'
+      ),
+      expected: 'failed to solve: rpc error: code = Unknown desc = failed to solve with frontend dockerfile.v0: failed to read dockerfile: open /tmp/buildkit-mount967127233/build.Dockerfile: no such file or directory'
+    },
+    {
+      // https://github.com/docker/buildx/issues/2382
+      name: 'Desktop build details after the error',
+      stderr: 'ERROR: failed to solve: process "/bin/sh -c exit 1" did not complete successfully: exit code: 1\n\nView build details: docker-desktop://dashboard/build/default/default/vetboddpu4fpa38o97opuyj0a\n',
+      expected: 'failed to solve: process "/bin/sh -c exit 1" did not complete successfully: exit code: 1'
+    },
+    {
+      // https://github.com/docker/buildx/issues/3173
+      name: 'bake HCL diagnostic after a source excerpt',
+      stderr: [
+        'docker-bake.hcl:13',
+        '--------------------',
+        '  12 |         contexts = { primary = "target:tgt1" }',
+        '  13 | >>>     tags = [ target.tgt1.tags.0, "secondary-image:latest" ]',
+        '  14 |     }',
+        '--------------------',
+        'ERROR: docker-bake.hcl:13,30-32: Attempt to index null value; This value is null, so it does not have any indices., and 1 other diagnostic(s)'
+      ].join('\n'),
+      expected: 'docker-bake.hcl:13,30-32: Attempt to index null value; This value is null, so it does not have any indices., and 1 other diagnostic(s)'
+    },
+    {
+      // https://github.com/docker/buildx/issues/3238
+      name: 'Windows file error after an incidental HTTP/2 diagnostic',
+      stderr: [
+        '2025/06/11 15:53:20 http2: server: error reading preface from client //./pipe/dockerDesktopLinuxEngine: file has already been closed',
+        'ERROR: resolve : CreateFile C:\\Users\\Gili\\Documents\\docker\\buildx\\src\\test\\resources\\missing: The system cannot find the file specified.'
+      ].join('\r\n'),
+      expected: 'resolve : CreateFile C:\\Users\\Gili\\Documents\\docker\\buildx\\src\\test\\resources\\missing: The system cannot find the file specified.'
+    },
+    {
+      // https://github.com/docker/buildx/issues/3374
+      name: 'terminal registry failure after secondary missing blob errors',
+      stderr: [
+        '#16 ERROR: blob sha256:117fe295ae589c229bf12bc2aef5912da375efb8228d2aae8e59b634cc91526c not found',
+        '#15 ERROR: blob sha256:117fe295ae589c229bf12bc2aef5912da375efb8228d2aae8e59b634cc91526c not found',
+        'ERROR: failed to build: failed to solve: failed to compute cache key: failed to copy: httpReadSeeker: failed open: unexpected status code https://ghcr.io/v2/osgeo/gdal/blobs/sha256:50fc4bfbbaf374c273c554992eb7e14b5e66dc6dfa59a72f46023825e5d6fcc9: 502 Bad Gateway'
+      ].join('\n'),
+      expected:
+        'failed to build: failed to solve: failed to compute cache key: failed to copy: httpReadSeeker: failed open: unexpected status code https://ghcr.io/v2/osgeo/gdal/blobs/sha256:50fc4bfbbaf374c273c554992eb7e14b5e66dc6dfa59a72f46023825e5d6fcc9: 502 Bad Gateway'
+    },
+    {
+      // https://github.com/docker/buildx/issues/4067
+      // The summary is generic here; the preceding node error stays in the logs.
+      name: 'builder removal summary after a detailed node error',
+      stderr: [
+        'failed to remove rmtimeout-531610: failed to remove node rmtimeout-5316100: Delete "http://%2Ftmp%2Ftmp.hU31tUGWsv%2Fdocker.sock/v1.55/volumes/buildx_buildkit_rmtimeout-5316100_state": context deadline exceeded',
+        'ERROR: failed to remove one or more builders'
+      ].join('\n'),
+      expected: 'failed to remove one or more builders'
+    },
+    {
+      name: 'debug stack trace after the error',
+      stderr: 'ERROR: failed to solve: context canceled\ngithub.com/docker/buildx/commands.runBuild\n\t/src/commands/build.go:100\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1700\n',
+      expected: 'failed to solve: context canceled'
+    },
+    {
+      name: 'CLI usage after the error',
+      stderr: "ERROR: docker: 'docker buildx build' requires 1 argument\n\nUsage:  docker buildx build [OPTIONS] PATH | URL | -\n\nRun 'docker buildx build --help' for more information\n",
+      expected: "docker: 'docker buildx build' requires 1 argument"
+    },
+    {
+      name: 'last summary wins',
+      stderr: 'ERROR: earlier error\n#2 ERROR: vertex error\nERROR: final error\nLearn more at https://docs.docker.com/\n',
+      expected: 'final error'
+    },
+    {
+      name: 'embedded error markers do not override the summary',
+      stderr: 'ERROR: build failed\n#2 ERROR: vertex error\nwarning: ERROR: embedded text\n',
+      expected: 'build failed'
+    },
+    {
+      name: 'ANSI colors and Windows line endings',
+      stderr: '\u001b[31mERROR:\u001b[0m failed to build: invalid tag\r\nLearn more at https://docs.docker.com/\r\n\r\n',
+      expected: 'failed to build: invalid tag'
+    },
+    {
+      name: 'carriage return separated output',
+      stderr: '#1 building\rERROR: build failed\rtrailing hint\r',
+      expected: 'build failed'
+    },
+    {
+      name: 'whitespace around the summary',
+      stderr: '\t ERROR:   build failed  \n\t hint\n',
+      expected: 'build failed'
+    },
+    {
+      name: 'last non-empty line fallback',
+      stderr: 'warning: something went wrong\n  build failed  \n\t\n',
+      expected: 'build failed'
+    },
+    {
+      name: 'ANSI colors in the fallback',
+      stderr: '\u001b[31mbuild failed\u001b[0m\n\u001b[0m',
+      expected: 'build failed'
+    },
+    {name: 'empty output', stderr: '', expected: 'unknown error'},
+    {name: 'whitespace-only output', stderr: ' \r\n\t\n', expected: 'unknown error'},
+    {name: 'empty summary', stderr: 'ERROR: \nLearn more at https://docs.docker.com/\n', expected: 'unknown error'},
+    {
+      // https://github.com/docker/build-push-action/issues/1610
+      name: 'long source and whitespace lines',
+      stderr: `${'x'.repeat(30000)}\n${' '.repeat(30000)}\nERROR: failed to solve: process "/bin/sh -c npm run build" did not complete successfully: exit code: 1\n`,
+      expected: 'failed to solve: process "/bin/sh -c npm run build" did not complete successfully: exit code: 1'
+    },
+    {
+      name: 'long whitespace lines without a summary',
+      stderr: `${'x'.repeat(30000)}\n${' '.repeat(30000)}\nbuild failed\n${' '.repeat(30000)}\n`,
+      expected: 'build failed'
+    }
+  ])('$name', ({stderr, expected}) => {
+    expect(Buildx.getErrorMessage(stderr)).toEqual(expected);
+  });
+});
+
 describe('versionSatisfies', () => {
   test.each([
     ['0.4.1', '>=0.3.2', true],

--- a/src/buildx/buildx.ts
+++ b/src/buildx/buildx.ts
@@ -16,6 +16,7 @@
 
 import fs from 'fs';
 import path from 'path';
+import {stripVTControlCharacters} from 'util';
 import * as core from '@actions/core';
 import * as semver from 'semver';
 
@@ -131,6 +132,19 @@ export class Buildx {
       throw new Error(`Cannot parse buildx version`);
     }
     return matches[1];
+  }
+
+  public static getErrorMessage(stderr: string): string {
+    const lines = stripVTControlCharacters(stderr).split(/[\r\n]/);
+    let lastLine = '';
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const line = lines[i].trim();
+      if (line.startsWith('ERROR:')) {
+        return line.slice('ERROR:'.length).trim() || 'unknown error';
+      }
+      lastLine ||= line;
+    }
+    return lastLine || 'unknown error';
   }
 
   public async versionSatisfies(range: string, version?: string): Promise<boolean> {


### PR DESCRIPTION
relates to:

<img width="711" height="190" alt="image" src="https://github.com/user-attachments/assets/bc1641b8-b47c-41fa-9264-2da0253d78d1" />

Prefer the final `ERROR:` summary over trailing help text, Desktop links, and debug output. Strip terminal formatting and fall back to the last non-empty line when no summary is present. Use a line scan to avoid the backtracking of the last-line regex used by actions.